### PR TITLE
Strengthen admin override controls and styling

### DIFF
--- a/self-paced-learning/blueprints/admin_routes.py
+++ b/self-paced-learning/blueprints/admin_routes.py
@@ -1275,14 +1275,21 @@ def admin_toggle_override():
         admin_service = get_admin_service()
 
         if request.method == "POST":
-            # Toggle override
-            result = admin_service.toggle_override()
-            return jsonify(result)
+            payload = request.get_json(silent=True) or {}
+
+            if "enabled" in payload:
+                result = admin_service.set_override(bool(payload.get("enabled")))
+            else:
+                result = admin_service.toggle_override()
+
+            status_code = 200 if result.get("success") else 400
+            return jsonify(result), status_code
         else:
             # Check current status
             override_status = admin_service.check_override_status()
-            return jsonify(override_status)
+            status_code = 200 if override_status.get("success") else 500
+            return jsonify(override_status), status_code
 
     except Exception as e:
         print(f"Error in admin override: {e}")
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"success": False, "error": str(e)}), 500

--- a/self-paced-learning/blueprints/api_routes.py
+++ b/self-paced-learning/blueprints/api_routes.py
@@ -443,10 +443,15 @@ def api_admin_status():
     try:
         progress_service = get_progress_service()
 
-        return jsonify({"admin_override": progress_service.get_admin_override_status()})
+        return jsonify(
+            {
+                "success": True,
+                "admin_override": progress_service.get_admin_override_status(),
+            }
+        )
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"success": False, "error": str(e)}), 500
 
 
 @api_bp.route("/admin/mark_complete", methods=["POST"])
@@ -456,8 +461,14 @@ def api_admin_mark_complete():
         progress_service = get_progress_service()
 
         data = request.get_json()
-        subject = data.get("subject")
-        subtopic = data.get("subtopic")
+        subject = data.get("subject") if data else None
+        subtopic = data.get("subtopic") if data else None
+
+        # Allow the frontend to omit subject/subtopic and fall back to the active quiz context
+        if not subject:
+            subject = session.get("current_subject")
+        if not subtopic:
+            subtopic = session.get("current_subtopic")
 
         if not subject or not subtopic:
             return jsonify({"error": "Subject and subtopic are required"}), 400

--- a/self-paced-learning/services/admin_service.py
+++ b/self-paced-learning/services/admin_service.py
@@ -674,7 +674,7 @@ class AdminService:
     # OVERRIDE AND TESTING FUNCTIONALITY
     # ============================================================================
 
-    def toggle_admin_override(self) -> Dict[str, Any]:
+    def toggle_override(self) -> Dict[str, Any]:
         """Toggle admin override status."""
         try:
             new_status = self.progress_service.toggle_admin_override()
@@ -688,9 +688,37 @@ class AdminService:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
-    def get_admin_status(self) -> Dict[str, Any]:
+    def set_override(self, enabled: bool) -> Dict[str, Any]:
+        """Explicitly set the admin override status."""
+        try:
+            status = self.progress_service.set_admin_override(enabled)
+            return {
+                "success": True,
+                "admin_override": status,
+                "message": f"Admin override {'enabled' if status else 'disabled'}",
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def check_override_status(self) -> Dict[str, Any]:
         """Get current admin override status."""
-        return {"admin_override": self.progress_service.get_admin_override_status()}
+        try:
+            return {
+                "success": True,
+                "admin_override": self.progress_service.get_admin_override_status(),
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    # Backwards compatibility helpers -------------------------------------------------
+
+    def toggle_admin_override(self) -> Dict[str, Any]:
+        """Backward compatible alias for toggle_override."""
+        return self.toggle_override()
+
+    def get_admin_status(self) -> Dict[str, Any]:
+        """Backward compatible alias for check_override_status."""
+        return self.check_override_status()
 
     def admin_mark_complete(self, subject: str, subtopic: str) -> Dict[str, Any]:
         """Mark a topic as complete for admin override."""

--- a/self-paced-learning/services/ai_service.py
+++ b/self-paced-learning/services/ai_service.py
@@ -289,9 +289,11 @@ class AIService:
         }
         analysis["allowed_tags"] = allowed_tags
 
+        normalized_missed_tags = self._normalize_tags(wrong_tag_candidates)
+
         fallback_tags = self._filter_allowed_tags(wrong_tag_candidates, allowed_lookup)
         if not fallback_tags:
-            fallback_tags = self._normalize_tags(wrong_tag_candidates)
+            fallback_tags = normalized_missed_tags
 
         submission_text = "".join(submission_details) if submission_details else "[No submission details available]"
         system_message = (
@@ -332,6 +334,8 @@ class AIService:
             )
 
         analysis["raw_ai_response"] = ai_response
+
+        analysis["missed_tags"] = normalized_missed_tags
 
         if ai_response:
             parsed_response = self._extract_json_object(ai_response)

--- a/self-paced-learning/static/css/styles.css
+++ b/self-paced-learning/static/css/styles.css
@@ -1716,6 +1716,122 @@ body.quiz-page {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
+/* --------------------------------------------------------------------------- */
+/* Admin override controls                                                     */
+/* --------------------------------------------------------------------------- */
+
+.admin-controls-floating {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.admin-override-panel {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: #ffffff;
+  padding: 12px 20px;
+  border-radius: 12px;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.admin-override-panel-inline {
+  position: relative;
+  margin: 20px auto;
+  justify-content: space-between;
+  max-width: 520px;
+  width: calc(100% - 40px);
+}
+
+.admin-override-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.admin-override-toggle {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.3s ease;
+}
+
+.admin-override-toggle-inline {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border: none;
+  box-shadow: 0 6px 18px rgba(102, 126, 234, 0.35);
+}
+
+.admin-override-toggle:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-1px);
+}
+
+.admin-override-toggle-inline:hover {
+  background: linear-gradient(135deg, #5d6fe5, #7e4bb4);
+}
+
+.override-active {
+  background: rgba(255, 255, 255, 0.3) !important;
+  color: #ffffff !important;
+  border-color: rgba(255, 255, 255, 0.45) !important;
+  box-shadow: 0 4px 14px rgba(255, 255, 255, 0.25);
+}
+
+.admin-action-button {
+  background: linear-gradient(135deg, #f2994a, #f2c94c);
+  color: #2d3436;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-action-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(242, 153, 74, 0.35);
+}
+
+@media (max-width: 768px) {
+  .admin-controls-floating {
+    top: 10px;
+    right: 10px;
+  }
+
+  .admin-override-panel {
+    padding: 10px 15px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-override-toggle,
+  .admin-override-toggle-inline {
+    font-size: 11px;
+    padding: 6px 10px;
+  }
+
+  .admin-override-panel-inline {
+    width: calc(100% - 30px);
+  }
+}
+
 .code-runner-placeholder {
   padding: 24px;
   text-align: center;

--- a/self-paced-learning/templates/python_subject.html
+++ b/self-paced-learning/templates/python_subject.html
@@ -42,7 +42,8 @@
             <button
               id="toggleOverrideBtn"
               onclick="toggleAdminOverride()"
-              class="action-btn secondary"
+              class="admin-override-toggle admin-override-toggle-inline"
+              type="button"
               title="Toggle admin override to bypass prerequisites"
             >
               <i class="fas fa-key"></i>
@@ -2590,11 +2591,15 @@
 
       // Admin override functionality
       function toggleAdminOverride() {
+        const btn = document.getElementById("toggleOverrideBtn");
+        const isActive = btn && btn.classList.contains("override-active");
+
         fetch("/admin/toggle-override", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
+          body: JSON.stringify({ enabled: !isActive }),
         })
           .then((response) => response.json())
           .then((data) => {
@@ -2622,6 +2627,12 @@
       function updateOverrideButton(isActive) {
         const btn = document.getElementById("toggleOverrideBtn");
         const status = document.getElementById("overrideStatus");
+
+        if (!btn || !status) {
+          return;
+        }
+
+        btn.dataset.active = isActive ? "true" : "false";
 
         if (isActive) {
           btn.classList.add("override-active");

--- a/self-paced-learning/templates/quiz.html
+++ b/self-paced-learning/templates/quiz.html
@@ -10,16 +10,17 @@
   </head>
   <body class="quiz-page">
     {% if admin_override %}
-    <div class="admin-controls">
-      <div class="admin-panel">
-        <div class="admin-info">
+    <div class="admin-controls-floating">
+      <div class="admin-override-panel">
+        <div class="admin-override-label">
           <i class="fas fa-shield-alt"></i>
           <span>Admin Override Active</span>
         </div>
         <button
           id="toggleOverride"
-          class="btn-override"
-          onclick="toggleAdminOverride()"
+          class="admin-override-toggle"
+          type="button"
+          onclick="disableAdminOverride()"
         >
           <i class="fas fa-power-off"></i>
           Disable Override
@@ -165,12 +166,13 @@
         });
 
       // Admin override functionality
-      function toggleAdminOverride() {
+      function disableAdminOverride() {
         fetch("/admin/toggle-override", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
+          body: JSON.stringify({ enabled: false }),
         })
           .then((response) => response.json())
           .then((data) => {
@@ -189,79 +191,6 @@
     </script>
 
     <style>
-      .admin-controls {
-        position: fixed;
-        top: 20px;
-        right: 20px;
-        z-index: 1000;
-      }
-
-      .admin-panel {
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        padding: 12px 20px;
-        border-radius: 12px;
-        box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
-        display: flex;
-        align-items: center;
-        gap: 15px;
-        backdrop-filter: blur(10px);
-      }
-
-      .admin-info {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-weight: 600;
-        font-size: 14px;
-      }
-
-      .admin-info i {
-        color: #ffd700;
-      }
-
-      .btn-override {
-        background: rgba(255, 255, 255, 0.2);
-        color: white;
-        border: 1px solid rgba(255, 255, 255, 0.3);
-        padding: 6px 12px;
-        border-radius: 6px;
-        cursor: pointer;
-        font-size: 12px;
-        font-weight: 600;
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        transition: all 0.3s ease;
-      }
-
-      .btn-override:hover {
-        background: rgba(255, 255, 255, 0.3);
-        transform: translateY(-1px);
-      }
-
-      @media (max-width: 768px) {
-        .admin-controls {
-          top: 10px;
-          right: 10px;
-        }
-
-        .admin-panel {
-          padding: 10px 15px;
-          flex-direction: column;
-          gap: 10px;
-        }
-
-        .admin-info {
-          font-size: 12px;
-        }
-
-        .btn-override {
-          font-size: 11px;
-          padding: 5px 10px;
-        }
-      }
-
       /* Correct answer highlighting */
       .correct-answer {
         background-color: #d4edda !important;

--- a/self-paced-learning/templates/results.html
+++ b/self-paced-learning/templates/results.html
@@ -12,6 +12,21 @@
     <script src="https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"></script>
   </head>
   <body>
+    {% if admin_override %}
+    <div
+      class="admin-override-panel admin-override-panel-inline"
+      id="resultsAdminOverridePanel"
+    >
+      <div class="admin-override-label">Admin Override Active</div>
+      <button
+        type="button"
+        id="disableOverrideResults"
+        class="admin-override-toggle"
+      >
+        Disable Override
+      </button>
+    </div>
+    {% endif %}
     <div class="blackboard-layout">
       <nav id="results-sidebar" class="sidebar">
         <div class="sidebar-header">
@@ -25,8 +40,8 @@
           {% if is_admin %}
           <button
             id="adminMarkCompleteButton"
-            class="action-button admin-button"
-            style="background: #dc3545; margin-bottom: 10px"
+            class="admin-action-button"
+            type="button"
           >
             Admin: Mark All Complete
           </button>
@@ -113,12 +128,16 @@
               const continueButton = document.getElementById("continueButton");
               const backToTopicsButton =
                 document.getElementById("backToTopicsButton");
+              const disableOverrideButton = document.getElementById(
+                "disableOverrideResults"
+              );
               const adminMarkCompleteButton = document.getElementById(
                 "adminMarkCompleteButton"
               );
 
               // --- State Tracking ---
               let completionState = {};
+              const videoLookupCache = new Map();
               let currentPlayer = null;
               let currentVideoTopic = null;
               let videoProgressChecker = null;
@@ -194,6 +213,59 @@
                 return topicMappings[normalizedTopic] || topic;
               }
 
+              function lookupVideoData(topic, completionKey) {
+                if (!VIDEO_DATA || typeof VIDEO_DATA !== "object") {
+                  return null;
+                }
+
+                const cacheKey = `${topic || ""}::${completionKey || ""}`;
+                if (videoLookupCache.has(cacheKey)) {
+                  return videoLookupCache.get(cacheKey);
+                }
+
+                const normalizedTopic = (topic || "").trim();
+                const normalizedCompletion = (completionKey || normalizedTopic).trim();
+
+                const candidateKeys = [];
+                const pushCandidate = (key) => {
+                  if (!key) return;
+                  const keyString = String(key).trim();
+                  if (!keyString) return;
+                  if (!candidateKeys.includes(keyString)) {
+                    candidateKeys.push(keyString);
+                  }
+                };
+
+                pushCandidate(getVideoKeyForTopic(normalizedCompletion));
+                pushCandidate(getVideoKeyForTopic(normalizedTopic));
+                pushCandidate(normalizedCompletion);
+                pushCandidate(normalizedTopic);
+
+                const lowerTopic = normalizedTopic.toLowerCase();
+                const lowerCompletion = normalizedCompletion.toLowerCase();
+                if (
+                  lowerTopic.includes("function") ||
+                  lowerTopic.includes("parameter") ||
+                  lowerTopic.includes("argument") ||
+                  lowerCompletion.includes("function") ||
+                  lowerCompletion.includes("parameter") ||
+                  lowerCompletion.includes("argument")
+                ) {
+                  pushCandidate("functions");
+                }
+
+                let found = null;
+                for (const key of candidateKeys) {
+                  if (VIDEO_DATA[key]) {
+                    found = { key, data: VIDEO_DATA[key] };
+                    break;
+                  }
+                }
+
+                videoLookupCache.set(cacheKey, found);
+                return found;
+              }
+
               // --- Simplified Click Handler ---
               document.addEventListener("click", function (e) {
                 const link = e.target.closest("a[data-action]");
@@ -263,13 +335,18 @@
                   if (!lesson) return;
 
                   const safeTopicId = topic.replace(/[^a-zA-Z0-9]/g, "_");
+                  const hasVideo = Boolean(lookupVideoData(topic));
                   const groupLi = document.createElement("li");
                   groupLi.className = "topic-group";
                   groupLi.innerHTML = `
                    <span>${lesson.title || topic}</span>
                    <ul>
                      <li id="read-${safeTopicId}"><a href="#" data-topic="${topic}" data-weak-topic="${topic}" data-action="read">Read Remedial Lesson</a></li>
-                     <li id="watch-${safeTopicId}"><a href="#" data-topic="${topic}" data-weak-topic="${topic}" data-action="watch">Watch Video</a></li>
+                     ${
+                       hasVideo
+                         ? `<li id="watch-${safeTopicId}"><a href="#" data-topic="${topic}" data-weak-topic="${topic}" data-action="watch">Watch Video</a></li>`
+                         : ""
+                     }
                    </ul>
                  `;
                   topicsNavList.appendChild(groupLi);
@@ -278,8 +355,14 @@
 
               // --- Helper Functions ---
               function buildCompletionState(topics) {
+                completionState = {};
                 topics.forEach((topic) => {
-                  completionState[topic] = { read: false, watched: false };
+                  const state = { read: false };
+                  const videoInfo = lookupVideoData(topic);
+                  if (videoInfo && videoInfo.data) {
+                    state.watched = false;
+                  }
+                  completionState[topic] = state;
                 });
               }
 
@@ -318,67 +401,107 @@
                 }
               });
 
+              if (disableOverrideButton) {
+                disableOverrideButton.addEventListener(
+                  "click",
+                  async function () {
+                    try {
+                      disableOverrideButton.disabled = true;
+                      const response = await fetch("/admin/toggle-override", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({ enabled: false }),
+                      });
+                      const data = await response.json();
+
+                      if (data.success) {
+                        window.location.reload();
+                      } else {
+                        disableOverrideButton.disabled = false;
+                        alert(
+                          data.error ||
+                            "Failed to disable admin override. Please try again."
+                        );
+                      }
+                    } catch (error) {
+                      console.error("Error disabling admin override", error);
+                      disableOverrideButton.disabled = false;
+                      alert(
+                        "A network error prevented disabling admin override."
+                      );
+                    }
+                  }
+                );
+              }
+
               // Admin mark complete functionality
               if (adminMarkCompleteButton) {
                 adminMarkCompleteButton.addEventListener("click", async function () {
                   if (
-                    confirm(
+                    !confirm(
                       "Mark all weak topics as complete? This will set all read and watch activities to 100% completion."
                     )
                   ) {
-                    try {
-                      // Get all current weak topics
-                      const weakTopics = Object.keys(completionState);
-                      let completedCount = 0;
+                    return;
+                  }
 
-                      // Mark each topic as complete
-                      for (const topic of weakTopics) {
-                        const response = await fetch("/api/admin/mark_complete", {
-                          method: "POST",
-                          headers: {
-                            "Content-Type": "application/json",
-                          },
-                          body: JSON.stringify({ topic: topic }),
-                        });
+                  if (!CURRENT_SUBJECT || !CURRENT_SUBTOPIC) {
+                    alert("Unable to determine the active subject and subtopic.");
+                    return;
+                  }
 
-                        if (response.ok) {
-                          // Mark both read and watched as complete
-                          completionState[topic].read = true;
-                          completionState[topic].watched = true;
-                          completedCount++;
+                  try {
+                    const response = await fetch("/api/admin/mark_complete", {
+                      method: "POST",
+                      headers: {
+                        "Content-Type": "application/json",
+                      },
+                      body: JSON.stringify({
+                        subject: CURRENT_SUBJECT,
+                        subtopic: CURRENT_SUBTOPIC,
+                      }),
+                    });
 
-                          // Update visual indicators for both read and watch
-                          const safeTopicId = topic.replace(/[^a-zA-Z0-9]/g, "_");
+                    const payload = await response.json().catch(() => ({}));
 
-                          // Mark read as complete
-                          const readElement = document.getElementById(
-                            `read-${safeTopicId}`
-                          );
-                          if (readElement) {
-                            readElement.classList.add("completed");
-                          }
+                    if (!response.ok || !payload.success) {
+                      throw new Error(payload.error || "Failed to mark topic as complete");
+                    }
 
-                          // Mark watch as complete
-                          const watchElement = document.getElementById(
-                            `watch-${safeTopicId}`
-                          );
-                          if (watchElement) {
-                            watchElement.classList.add("completed");
-                          }
+                    // Update local completion state for all weak topics
+                    const weakTopics = Object.keys(completionState);
+                    weakTopics.forEach((topic) => {
+                      if (!completionState[topic]) {
+                        completionState[topic] = {};
+                      }
+
+                      const state = completionState[topic];
+
+                      const safeTopicId = topic.replace(/[^a-zA-Z0-9]/g, "_");
+
+                      if ("read" in state) {
+                        state.read = true;
+                        const readElement = document.getElementById(`read-${safeTopicId}`);
+                        if (readElement) {
+                          readElement.classList.add("completed");
                         }
                       }
 
-                      // Show success message
-                      alert(
-                        `Successfully marked ${completedCount} topics as complete!`
-                      );
+                      if ("watched" in state) {
+                        state.watched = true;
+                        const watchElement = document.getElementById(`watch-${safeTopicId}`);
+                        if (watchElement) {
+                          watchElement.classList.add("completed");
+                        }
+                      }
+                    });
 
-                      // Check if all topics are now complete
-                      checkCompletionAndToggleButton();
-                    } catch (error) {
-                      console.error("Error marking topics complete:", error);
-                      alert("Error marking topics complete. Please try again.");
-                    }
+                    alert(payload.message || "Successfully marked this topic as complete.");
+
+                    checkCompletionAndToggleButton();
+                  } catch (error) {
+                    console.error("Error marking topics complete:", error);
+                    alert("Error marking topics complete. Please try again.");
                   }
                 });
               }
@@ -465,27 +588,9 @@
                 // Hide welcome message
                 welcomeMessageContainer.classList.add("hidden");
 
-                // Map the topic to an actual video key
-                const videoKey = getVideoKeyForTopic(completionKeyToUse);
-                const fallbackVideoKey = getVideoKeyForTopic(topic);
-
-                // Find video data using mapped keys
-                let videoData =
-                  VIDEO_DATA[videoKey] ||
-                  VIDEO_DATA[fallbackVideoKey] ||
-                  VIDEO_DATA[completionKeyToUse] ||
-                  VIDEO_DATA[topic];
-
-                // If still no video found, try to find any functions video as a default for function-related topics
-                if (
-                  !videoData &&
-                  (completionKeyToUse.includes("function") ||
-                    topic.includes("function") ||
-                    completionKeyToUse.includes("parameter") ||
-                    completionKeyToUse.includes("argument"))
-                ) {
-                  videoData = VIDEO_DATA["functions"];
-                }
+                const lookupResult = lookupVideoData(topic, completionKeyToUse);
+                const videoData = lookupResult ? lookupResult.data : null;
+                const resolvedKey = lookupResult ? lookupResult.key : null;
 
                 if (!videoData) {
                   contentDisplayArea.innerHTML = `
@@ -520,11 +625,9 @@
                   <div id="video-player-container">
                     <div class="video-header">
                       <h2>${videoData.title || completionKeyToUse}</h2>
-                      ${
-                        videoKey !== completionKeyToUse
-                          ? `<p><em>Note: Showing "${videoData.title}" which covers topics related to "${completionKeyToUse}"</em></p>`
-                          : ""
-                      }
+                      ${resolvedKey && resolvedKey !== completionKeyToUse
+                        ? `<p><em>Note: Showing "${videoData.title}" which covers topics related to "${completionKeyToUse}"</em></p>`
+                        : ""}
                     </div>
                     <div class="video-wrapper">
                       <div id="youtube-player"></div>
@@ -569,7 +672,11 @@
                */
               function updateCompletionState(topic, action) {
                 if (!completionState[topic]) {
-                  completionState[topic] = { read: false, watched: false };
+                  completionState[topic] = {};
+                }
+
+                if (!(action in completionState[topic])) {
+                  return;
                 }
 
                 if (completionState[topic][action]) {
@@ -603,13 +710,13 @@
 
                 let allCompleted = true;
 
-                for (const topic in completionState) {
-                  if (
-                    !completionState[topic].read ||
-                    !completionState[topic].watched
-                  ) {
-                    allCompleted = false;
-                    break;
+                topicLoop: for (const topic in completionState) {
+                  const actions = completionState[topic];
+                  for (const requirement in actions) {
+                    if (!actions[requirement]) {
+                      allCompleted = false;
+                      break topicLoop;
+                    }
                   }
                 }
 

--- a/self-paced-learning/tests/test_admin_override_controls.py
+++ b/self-paced-learning/tests/test_admin_override_controls.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import unittest
+from flask import render_template
+
+# Ensure the application modules are importable when pytest adjusts sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app_refactored import app
+from services import get_progress_service
+
+
+class TestAdminOverrideControls(unittest.TestCase):
+    """Validate admin override toggling and prerequisite enforcement."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = app
+        cls.client = cls.app.test_client()
+        cls.progress_service = get_progress_service()
+
+    def setUp(self):
+        # Ensure a clean session for each test run
+        with self.client.session_transaction() as sess:
+            sess.clear()
+
+    def test_toggle_override_endpoint(self):
+        """POST /admin/toggle-override should enable and disable override explicitly."""
+        # Initial status should be disabled
+        response = self.client.get("/admin/toggle-override")
+        data = response.get_json()
+        self.assertTrue(data["success"])
+        self.assertFalse(data["admin_override"])
+
+        # Enable override via POST toggle
+        enable_response = self.client.post("/admin/toggle-override")
+        enable_data = enable_response.get_json()
+        self.assertTrue(enable_data["success"])
+        self.assertTrue(enable_data["admin_override"])
+
+        # API status endpoint should reflect enabled override
+        status_response = self.client.get("/api/admin/status")
+        status_data = status_response.get_json()
+        self.assertTrue(status_data["success"])
+        self.assertTrue(status_data["admin_override"])
+
+        # Explicitly disable override
+        disable_response = self.client.post(
+            "/admin/toggle-override", json={"enabled": False}
+        )
+        disable_data = disable_response.get_json()
+        self.assertTrue(disable_data["success"])
+        self.assertFalse(disable_data["admin_override"])
+
+        with self.client.session_transaction() as sess:
+            self.assertFalse(sess.get("admin_override", False))
+
+    def test_prerequisites_respected_when_override_off(self):
+        """Prerequisites should block quiz access when override is disabled."""
+        with self.app.test_request_context():
+            self.progress_service.clear_all_session_data()
+            self.progress_service.set_admin_override(False)
+            prerequisites = self.progress_service.check_quiz_prerequisites(
+                "python", "functions"
+            )
+
+            # Ensure prerequisites exist and are enforced
+            self.assertTrue(prerequisites["has_prerequisites"])
+            self.assertFalse(prerequisites["can_take_quiz"])
+
+            # Enabling override should bypass the gate
+            self.progress_service.set_admin_override(True)
+            bypassed = self.progress_service.check_quiz_prerequisites(
+                "python", "functions"
+            )
+            self.assertTrue(bypassed["can_take_quiz"])
+
+    def test_results_template_hides_admin_controls_when_disabled(self):
+        """Results page should only render admin controls while override is active."""
+        base_payload = {
+            "analysis": {"score": {"correct": 0, "total": 0, "percentage": 0}},
+            "ANALYSIS_RESULTS": {"score": {"correct": 0, "total": 0, "percentage": 0}},
+            "answers": [],
+            "subject": "python",
+            "subtopic": "functions",
+            "CURRENT_SUBJECT": "python",
+            "CURRENT_SUBTOPIC": "functions",
+            "LESSON_PLANS": {},
+            "VIDEO_DATA": {},
+            "video_recommendations": [],
+            "show_remedial": False,
+            "quiz_generation_error": None,
+        }
+
+        with self.app.test_request_context():
+            html_disabled = render_template(
+                "results.html",
+                **base_payload,
+                admin_override=False,
+                is_admin=False,
+            )
+
+        self.assertNotIn("Disable Override", html_disabled)
+        self.assertNotIn("Admin: Mark All Complete", html_disabled)
+
+        with self.app.test_request_context():
+            html_enabled = render_template(
+                "results.html",
+                **base_payload,
+                admin_override=True,
+                is_admin=True,
+            )
+
+        self.assertIn("Disable Override", html_enabled)
+        self.assertIn("Admin: Mark All Complete", html_enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow the admin override to be explicitly enabled or disabled through the progress and admin services while keeping consistent API responses
- refresh the quiz, results, and subject pages with shared override styling and hide the mark-all-complete shortcut whenever the override is inactive
- add targeted tests that cover the override endpoints, prerequisite gating, and results template rendering

## Testing
- `pytest self-paced-learning/tests/test_admin_override_controls.py`
- `flake8` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e06398fca0832f8ca9162bfb69ffe3