### PR TITLE
Implement staged quiz analysis with async AI enhancement

### DIFF
--- a/self-paced-learning/services/ai_service.py
+++ b/self-paced-learning/services/ai_service.py
@@ -4,40 +4,50 @@ Handles all AI-powered features including OpenAI integration, quiz analysis,
 and learning recommendations. Extracts AI logic from the main application routes.
 """
 
-import openai
-import os
-from typing import Dict, List, Optional, Any
+from __future__ import annotations
+
+import hashlib
 import json
+import os
 import re
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import openai
+
+from .quiz_analysis_utils import compute_basic_quiz_analysis, filter_allowed_tags
 
 try:
     from openai import OpenAI as OpenAIClient
-except ImportError:
+except ImportError:  # pragma: no cover - optional dependency path
     OpenAIClient = None
 
 
 class AIService:
     """Service class for handling AI-powered features."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the AI service with OpenAI configuration."""
         self.api_key = os.getenv("OPENAI_API_KEY")
         self.default_model = os.getenv("OPENAI_MODEL", "gpt-4")
         self.client: Optional[Any] = None
+        self._analysis_cache: Dict[str, Dict[str, Any]] = {}
+        self._cache_lock = threading.Lock()
 
         if self.api_key and OpenAIClient:
             try:
                 self.client = OpenAIClient(api_key=self.api_key)
             except TypeError:
-                self.client = OpenAIClient()
-            except Exception as exc:
+                self.client = OpenAIClient()  # type: ignore[call-arg]
+            except Exception as exc:  # pragma: no cover - defensive log path
                 print(f"Warning: failed to initialize OpenAI client: {exc}")
                 self.client = None
 
         if self.api_key:
             try:
                 openai.api_key = self.api_key
-            except Exception:
+            except Exception:  # pragma: no cover - OpenAI import optional
                 pass
         else:
             print("Warning: OPENAI_API_KEY not set. AI features will not work.")
@@ -46,10 +56,9 @@ class AIService:
         """Check if AI service is available (API key configured)."""
         return self.api_key is not None
 
-    # ============================================================================
+    # =======================================================================
     # CORE AI API METHODS
-    # ============================================================================
-
+    # =======================================================================
 
     def call_openai_api(
         self,
@@ -59,8 +68,10 @@ class AIService:
         max_tokens: int = 1500,
         temperature: float = 0.2,
         expect_json_output: bool = False,
+        timeout: int = 15,
+        max_attempts: int = 3,
     ) -> Optional[str]:
-        """Helper function to call the OpenAI API with optional JSON expectations."""
+        """Helper function to call the OpenAI API with retries and timeouts."""
         if not self.is_available():
             return None
 
@@ -74,57 +85,79 @@ class AIService:
         ]
 
         model_to_use = model or getattr(self, "default_model", "gpt-4")
-
-        kwargs = {
+        kwargs: Dict[str, Any] = {
             "model": model_to_use,
             "messages": messages,
             "max_tokens": max_tokens,
             "temperature": temperature,
         }
-
         if expect_json_output:
             kwargs["response_format"] = {"type": "json_object"}
 
+        kwargs_with_timeout = dict(kwargs)
+        kwargs_with_timeout["request_timeout"] = timeout
+        kwargs_with_timeout.setdefault("timeout", timeout)
+
         last_error: Optional[Exception] = None
+        backoff_seconds = 1.0
 
-        if getattr(self, "client", None) and getattr(self.client, "chat", None):
+        def _invoke(callable_obj, call_kwargs):
             try:
-                response = self.client.chat.completions.create(**kwargs)
-                content = self._extract_content_from_response(response)
-                if content:
-                    return content.strip()
-            except Exception as exc:
-                last_error = exc
-
-        for api_call in (
-            lambda: openai.ChatCompletion.create(**kwargs),
-            lambda: openai.chat.completions.create(**kwargs),
-        ):
-            try:
-                response = api_call()
-                content = self._extract_content_from_response(response)
-                if content:
-                    return content.strip()
-            except AttributeError as exc:
-                last_error = exc
-            except Exception as exc:
-                last_error = exc
-
-        if getattr(self, "client", None) and getattr(self.client, "responses", None):
-            try:
-                prompt_text = "\n".join(message["content"] for message in messages if message.get("content"))
-                response_kwargs = {
-                    "model": model_to_use,
-                    "input": prompt_text,
-                    "temperature": temperature,
-                    "max_output_tokens": max_tokens,
+                return callable_obj(**call_kwargs)
+            except TypeError:
+                trimmed = {
+                    k: v
+                    for k, v in call_kwargs.items()
+                    if k not in ("timeout", "request_timeout")
                 }
-                response = self.client.responses.create(**response_kwargs)
-                content = self._extract_content_from_response(response)
-                if content:
-                    return content.strip()
-            except Exception as exc:
-                last_error = exc
+                return callable_obj(**trimmed)
+
+        for attempt in range(1, max_attempts + 1):
+            if getattr(self, "client", None) and getattr(self.client, "chat", None):
+                try:
+                    response = _invoke(self.client.chat.completions.create, kwargs_with_timeout)
+                    content = self._extract_content_from_response(response)
+                    if content:
+                        return content.strip()
+                except Exception as exc:
+                    last_error = exc
+
+            for api_call in (
+                lambda: _invoke(openai.ChatCompletion.create, kwargs_with_timeout),
+                lambda: _invoke(openai.chat.completions.create, kwargs_with_timeout),
+            ):
+                try:
+                    response = api_call()
+                    content = self._extract_content_from_response(response)
+                    if content:
+                        return content.strip()
+                except AttributeError as exc:
+                    last_error = exc
+                except Exception as exc:
+                    last_error = exc
+
+            if getattr(self, "client", None) and getattr(self.client, "responses", None):
+                try:
+                    prompt_text = "\n".join(
+                        message["content"] for message in messages if message.get("content")
+                    )
+                    response_kwargs = {
+                        "model": model_to_use,
+                        "input": prompt_text,
+                        "temperature": temperature,
+                        "max_output_tokens": max_tokens,
+                        "timeout": timeout,
+                    }
+                    response = _invoke(self.client.responses.create, response_kwargs)
+                    content = self._extract_content_from_response(response)
+                    if content:
+                        return content.strip()
+                except Exception as exc:
+                    last_error = exc
+
+            if attempt < max_attempts:
+                time.sleep(backoff_seconds)
+                backoff_seconds *= 2
 
         if last_error:
             print(f"Error calling OpenAI API: {last_error}")
@@ -179,7 +212,6 @@ class AIService:
                     return text_value
         return None
 
-
     def _flatten_content(self, content: Any) -> Optional[str]:
         if not content:
             return None
@@ -209,127 +241,91 @@ class AIService:
                 return content_value
         return None
 
-    # ============================================================================
+    # =======================================================================
     # QUIZ ANALYSIS AND RECOMMENDATIONS
-    # ============================================================================
+    # =======================================================================
 
     def analyze_quiz_performance(
-        self, questions: List[Dict], answers: List[str], subject: str, subtopic: str
+        self,
+        questions: List[Dict],
+        answers: List[str],
+        subject: str,
+        subtopic: str,
+        base_analysis: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Analyze quiz performance and generate tag-aware recommendations."""
         from services import get_data_service
 
-        total_questions = len(questions)
-        normalized_answers = [str(answer) if answer is not None else "" for answer in answers]
-        correct_answers = 0
-        submission_details: List[str] = []
-        wrong_indices: List[int] = []
-        wrong_tag_candidates: List[str] = []
+        data_service = get_data_service()
+        if base_analysis is None:
+            base_analysis = compute_basic_quiz_analysis(
+                questions,
+                answers,
+                subject,
+                subtopic,
+                data_service=data_service,
+                include_submission_details=True,
+            )
 
-        for idx, question in enumerate(questions):
-            user_answer = normalized_answers[idx] if idx < len(normalized_answers) else ""
-            question_type = (question.get("type") or "multiple_choice").strip().lower()
-            status = "Incorrect"
+        analysis = dict(base_analysis)
+        analysis.setdefault("analysis_stage", "basic")
+        analysis.setdefault("feedback", analysis.get("basic_feedback", ""))
 
-            if question_type == "coding":
-                status = "For AI Review"
-            elif self._is_answer_correct(question, user_answer):
-                status = "Correct"
-                correct_answers += 1
-            else:
-                wrong_indices.append(idx)
-                wrong_tag_candidates.extend(self._collect_question_tags(question))
-
-            correct_answer_text = self._resolve_correct_answer(question)
-            detail_lines = [
-                f"Question {idx + 1} (Type: {question_type}): {question.get('question', 'N/A')}",
-                "Student's Answer:",
-                "---",
-                user_answer if user_answer else "[No answer provided]",
-                "---",
-            ]
-            if correct_answer_text:
-                detail_lines.append(f"Correct Answer: {correct_answer_text}")
-            detail_lines.append(f"Status: {status}")
-            submission_details.append("\n".join(detail_lines) + "\n")
-
-        score_percentage = (
-            round((correct_answers / total_questions) * 100)
-            if total_questions > 0
-            else 0
-        )
-
-        analysis: Dict[str, Any] = {
-            "score": {
-                "correct": correct_answers,
-                "total": total_questions,
-                "percentage": score_percentage,
-            },
-            "weak_topics": [],
-            "weak_tags": [],
-            "weak_areas": [],
-            "feedback": "",
-            "ai_analysis": "",
-            "recommendations": [],
-            "submission_details": submission_details,
-            "wrong_question_indices": wrong_indices,
-            "allowed_tags": [],
-            "used_ai": False,
-        }
-
-        try:
-            data_service = get_data_service()
-            allowed_tags = data_service.get_subject_allowed_tags(subject)
-        except Exception as exc:
-            print(f"Error getting allowed tags for {subject}: {exc}")
-            allowed_tags = []
-
+        allowed_tags = analysis.get("allowed_tags") or data_service.get_subject_allowed_tags(subject)
+        analysis["allowed_tags"] = allowed_tags or []
         allowed_lookup = {
-            str(tag).lower(): str(tag) for tag in allowed_tags if isinstance(tag, str)
+            str(tag).lower(): str(tag) for tag in (allowed_tags or []) if isinstance(tag, str)
         }
-        analysis["allowed_tags"] = allowed_tags
 
-        fallback_tags = self._filter_allowed_tags(wrong_tag_candidates, allowed_lookup)
-        if not fallback_tags:
-            fallback_tags = self._normalize_tags(wrong_tag_candidates)
+        fallback_tags = analysis.get("weak_tags") or analysis.get("weak_topics") or []
+        submission_details = analysis.get("submission_details") or []
+        if not submission_details:
+            submission_details = [
+                "\n".join(
+                    [
+                        f"Question {idx + 1}: {question.get('question', 'N/A')}",
+                        f"Answer Provided: {answers[idx] if idx < len(answers) else ''}",
+                    ]
+                )
+                for idx, question in enumerate(questions)
+            ]
 
-        submission_text = "".join(submission_details) if submission_details else "[No submission details available]"
-        system_message = (
-            "You are an expert instructor. Your task is to analyze a student's quiz performance, "
-            "classify their errors against a predefined list of topics, and evaluate their submitted code when provided."
-        )
-        allowed_tags_str = json.dumps(allowed_tags) if allowed_tags else "[]"
+        cache_key = self._build_cache_key(questions, answers, subject, subtopic)
+        cached = self._get_cached_analysis(cache_key)
+        if cached:
+            merged = dict(analysis)
+            merged.update({k: v for k, v in cached.items() if v is not None})
+            return merged
 
+        if not self.is_available():
+            return analysis
+
+        allowed_tags_str = json.dumps(analysis.get("allowed_tags") or [])
         prompt_parts = [
             "You are analyzing a student's quiz submission which includes multiple choice, fill-in-the-blank, and coding questions.",
             "Based on the incorrect answers and their submitted code, identify the concepts they are weak in.",
             f"You MUST choose the weak concepts from this predefined list ONLY: {allowed_tags_str}",
-            "For coding questions marked 'For AI Review', evaluate if the student's code:",
-            "1. Correctly solves the problem",
-            "2. Uses appropriate syntax and conventions",
-            "3. Demonstrates understanding of the underlying concepts",
-            "Compare their code with the provided sample solution when available.",
-            "Provide your analysis as a single JSON object with two keys:",
-            ' - "detailed_feedback": (string) Your textual analysis, including specific feedback on coding attempts, what they did well, and areas for improvement.',
-            ' - "weak_concept_tags": (JSON list of strings) The list of weak concepts from the ALLOWED TAGS list. If there are no weaknesses, provide an empty list [].',
-            f"Overall score: {correct_answers}/{total_questions} correct ({score_percentage}%).",
+            "For coding questions, comment on syntax, logic, and understanding.",
+            "Provide your analysis as a JSON object with keys 'detailed_feedback' and 'weak_concept_tags'.",
+            f"Overall score: {analysis['score']['correct']}/{analysis['score']['total']} correct ({analysis['score']['percentage']}%).",
             "Here is the student's submission:",
             "--- START OF SUBMISSION ---",
-            submission_text,
+            "".join(submission_details) if submission_details else "[No submission details available]",
             "--- END OF SUBMISSION ---",
         ]
-        prompt = "\n".join(prompt_parts)
+        prompt = "\n".join(part for part in prompt_parts if part)
 
-        ai_response = None
-        if self.is_available():
-            ai_response = self.call_openai_api(
-                prompt,
-                model=getattr(self, "default_model", "gpt-4"),
-                system_message=system_message,
-                max_tokens=1500,
-                temperature=0.1,
-                expect_json_output=True,
-            )
+        ai_response = self.call_openai_api(
+            prompt,
+            model=getattr(self, "default_model", "gpt-4"),
+            system_message=(
+                "You are an expert instructor. Analyze quiz performance, classify errors against allowed topics, "
+                "and provide supportive feedback."
+            ),
+            max_tokens=1200,
+            temperature=0.1,
+            expect_json_output=True,
+        )
 
         analysis["raw_ai_response"] = ai_response
 
@@ -339,17 +335,22 @@ class AIService:
                 candidate_tags = parsed_response.get("weak_concept_tags") or []
                 if isinstance(candidate_tags, str):
                     candidate_tags = [candidate_tags]
-                validated_tags = self._filter_allowed_tags(candidate_tags, allowed_lookup)
+                validated_tags = filter_allowed_tags(candidate_tags, allowed_lookup)
                 if not validated_tags:
                     validated_tags = fallback_tags
-                feedback = parsed_response.get("detailed_feedback") or parsed_response.get("feedback") or ""
-
+                feedback = (
+                    parsed_response.get("detailed_feedback")
+                    or parsed_response.get("feedback")
+                    or analysis.get("feedback")
+                    or ""
+                )
                 analysis["weak_topics"] = validated_tags
                 analysis["weak_tags"] = validated_tags
                 analysis["weak_areas"] = validated_tags
                 analysis["feedback"] = feedback
                 analysis["ai_analysis"] = feedback
                 analysis["used_ai"] = True
+                analysis["analysis_stage"] = "enhanced"
             else:
                 analysis["weak_topics"] = fallback_tags
                 analysis["weak_tags"] = fallback_tags
@@ -359,122 +360,59 @@ class AIService:
             analysis["weak_tags"] = fallback_tags
             analysis["weak_areas"] = fallback_tags
 
-        if not analysis["feedback"]:
-            if fallback_tags:
-                analysis["feedback"] = (
-                    f"You answered {correct_answers} out of {total_questions} correctly ("
-                    f"{score_percentage}%). Focus on reviewing: {', '.join(fallback_tags)}."
-                )
-            else:
-                analysis["feedback"] = (
-                    f"Excellent work scoring {score_percentage}%! Keep practicing to reinforce your understanding."
-                )
-            analysis["ai_analysis"] = analysis["feedback"]
+        if not analysis.get("recommendations"):
+            analysis["recommendations"] = self._generate_recommendations(
+                analysis["score"]["percentage"],
+                analysis.get("weak_topics", []),
+                subject,
+                subtopic,
+            )
 
-        analysis["recommendations"] = self._generate_recommendations(
-            score_percentage, analysis["weak_topics"], subject, subtopic
-        )
+        if analysis.get("used_ai"):
+            self._set_cached_analysis(
+                cache_key,
+                {
+                    "weak_topics": analysis.get("weak_topics"),
+                    "weak_tags": analysis.get("weak_tags"),
+                    "weak_areas": analysis.get("weak_areas"),
+                    "feedback": analysis.get("feedback"),
+                    "ai_analysis": analysis.get("ai_analysis"),
+                    "used_ai": analysis.get("used_ai"),
+                    "analysis_stage": analysis.get("analysis_stage"),
+                    "raw_ai_response": analysis.get("raw_ai_response"),
+                },
+            )
 
         return analysis
 
-    def _resolve_correct_answer(self, question: Dict[str, Any]) -> str:
-        question_type = (question.get("type") or "multiple_choice").strip().lower()
-        if question_type == "multiple_choice":
-            options = question.get("options", []) or []
-            answer_index = question.get("answer_index")
-            if answer_index is None:
-                answer_index = question.get("correct_answer_index")
-            if isinstance(answer_index, int) and 0 <= answer_index < len(options):
-                return str(options[answer_index])
-            return str(question.get("correct_answer", ""))
-        if question_type == "fill_in_the_blank":
-            correct = question.get("correct_answer")
-            if isinstance(correct, list):
-                return ", ".join(str(value) for value in correct)
-            return str(correct or question.get("answer", ""))
-        if question_type == "coding":
-            for key in ("sample_solution", "solution", "correct_answer"):
-                value = question.get(key)
-                if value:
-                    return str(value)
-            return ""
-        return str(question.get("correct_answer", ""))
+    def _build_cache_key(
+        self,
+        questions: List[Dict[str, Any]],
+        answers: List[str],
+        subject: str,
+        subtopic: str,
+    ) -> str:
+        payload = {
+            "subject": subject,
+            "subtopic": subtopic,
+            "questions": [
+                question.get("id")
+                or question.get("question_id")
+                or question.get("question", str(index))
+                for index, question in enumerate(questions)
+            ],
+            "answers": list(answers),
+        }
+        serialized = json.dumps(payload, sort_keys=True)
+        return hashlib.sha1(serialized.encode("utf-8")).hexdigest()
 
-    def _is_answer_correct(self, question: Dict[str, Any], user_answer: str) -> bool:
-        question_type = (question.get("type") or "multiple_choice").strip().lower()
-        answer_text = self._resolve_correct_answer(question)
-        user_clean = (user_answer or "").strip()
-        if not user_clean:
-            return False
-        if question_type == "multiple_choice":
-            return user_clean == answer_text.strip()
-        if question_type == "fill_in_the_blank":
-            acceptable = []
-            if answer_text:
-                acceptable.extend(
-                    [part.strip().lower() for part in answer_text.split(",") if part.strip()]
-                )
-            raw_list = question.get("correct_answers") or question.get("acceptable_answers")
-            if isinstance(raw_list, list):
-                acceptable.extend(
-                    [str(item).strip().lower() for item in raw_list if str(item).strip()]
-                )
-            return user_clean.lower() in acceptable if acceptable else False
-        if question_type == "coding":
-            return False
-        return user_clean.lower() == answer_text.strip().lower()
+    def _get_cached_analysis(self, cache_key: str) -> Optional[Dict[str, Any]]:
+        with self._cache_lock:
+            return self._analysis_cache.get(cache_key)
 
-    def _collect_question_tags(self, question: Dict[str, Any]) -> List[str]:
-        tags: List[str] = []
-        raw_tags = question.get("tags")
-        if isinstance(raw_tags, list):
-            tags.extend(str(tag) for tag in raw_tags)
-        elif isinstance(raw_tags, str):
-            tags.append(raw_tags)
-
-        topic = question.get("topic")
-        if isinstance(topic, list):
-            tags.extend(str(tag) for tag in topic)
-        elif isinstance(topic, str):
-            tags.append(topic)
-
-        return tags
-
-    def _filter_allowed_tags(self, tags: List[str], allowed_lookup: Dict[str, str]) -> List[str]:
-        if not tags:
-            return []
-        if not allowed_lookup:
-            return self._normalize_tags(tags)
-        filtered: List[str] = []
-        seen = set()
-        for tag in tags:
-            if not isinstance(tag, str):
-                continue
-            cleaned = tag.strip()
-            if not cleaned:
-                continue
-            key = cleaned.lower()
-            if key not in allowed_lookup or key in seen:
-                continue
-            seen.add(key)
-            filtered.append(allowed_lookup[key])
-        return filtered
-
-    def _normalize_tags(self, tags: List[str]) -> List[str]:
-        normalized: List[str] = []
-        seen = set()
-        for tag in tags or []:
-            if not isinstance(tag, str):
-                continue
-            cleaned = tag.strip()
-            if not cleaned:
-                continue
-            key = cleaned.lower()
-            if key in seen:
-                continue
-            seen.add(key)
-            normalized.append(cleaned)
-        return normalized
+    def _set_cached_analysis(self, cache_key: str, analysis: Dict[str, Any]) -> None:
+        with self._cache_lock:
+            self._analysis_cache[cache_key] = analysis
 
     def _extract_json_object(self, response_text: str) -> Optional[Dict[str, Any]]:
         if not response_text:
@@ -493,55 +431,12 @@ class AIService:
             except json.JSONDecodeError:
                 return None
         return None
-    def _create_analysis_prompt(
-        self,
-        questions: List[Dict],
-        answers: List[str],
-        subject: str,
-        subtopic: str,
-        score: float,
-        weak_areas: List[str],
-    ) -> str:
-        """Create a prompt for AI analysis of quiz performance."""
-        prompt = f"""
-Analyze a student's quiz performance for {subject} - {subtopic}.
-
-Quiz Results:
-- Score: {score:.1f}% ({len([a for a, q in zip(answers, questions) if a.lower().strip() == q.get('correct_answer', '').lower().strip()])} out of {len(questions)} correct)
-- Weak areas: {', '.join(weak_areas) if weak_areas else 'None identified'}
-
-Questions and Answers:
-"""
-
-        for i, (question, answer) in enumerate(zip(questions, answers)):
-            correct = question.get("correct_answer", "")
-            is_correct = answer.lower().strip() == correct.lower().strip()
-
-            prompt += f"""
-Q{i+1}: {question.get('question', '')}
-Student Answer: {answer}
-Correct Answer: {correct}
-Result: {'+' if is_correct else '-'}
-
-"""
-
-        prompt += """
-Provide a brief, encouraging analysis focusing on:
-1. Strengths demonstrated
-2. Specific areas for improvement
-3. Study suggestions
-4. Next steps for learning
-
-Keep the response concise and student-friendly.
-"""
-
-        return prompt
 
     def _generate_recommendations(
         self, score: float, weak_areas: List[str], subject: str, subtopic: str
     ) -> List[str]:
         """Generate learning recommendations based on performance."""
-        recommendations = []
+        recommendations: List[str] = []
 
         if score >= 80:
             recommendations.append(
@@ -572,37 +467,16 @@ Keep the response concise and student-friendly.
         self, questions: List[Dict], answers: List[str]
     ) -> Dict[str, Any]:
         """Provide fallback analysis when AI is not available."""
-        total_questions = len(questions)
-        normalized_answers = [str(answer) if answer is not None else "" for answer in answers]
-        correct_answers = 0
-        for idx, question in enumerate(questions):
-            user_answer = normalized_answers[idx] if idx < len(normalized_answers) else ""
-            if self._is_answer_correct(question, user_answer):
-                correct_answers += 1
-
-        score_percentage = (
-            (correct_answers / total_questions) * 100 if total_questions > 0 else 0
+        basic = compute_basic_quiz_analysis(questions, answers, "", "", data_service=None)
+        basic["feedback"] = (
+            "AI analysis not available. Please review your answers and try again."
         )
+        basic["ai_analysis"] = basic["feedback"]
+        return basic
 
-        return {
-            "score": {
-                "correct": correct_answers,
-                "total": total_questions,
-                "percentage": score_percentage,
-            },
-            "weak_areas": [],
-            "weak_topics": [],
-            "weak_tags": [],
-            "ai_analysis": "AI analysis not available. Please review your answers and try again.",
-            "feedback": "AI analysis not available. Please review your answers and try again.",
-            "recommendations": self._generate_recommendations(
-                score_percentage, [], "", ""
-            ),
-        }
-
-    # ============================================================================
+    # =======================================================================
     # VIDEO RECOMMENDATIONS
-    # ============================================================================
+    # =======================================================================
 
     def recommend_videos(
         self,
@@ -616,38 +490,30 @@ Keep the response concise and student-friendly.
             return []
 
         if not weak_areas:
-            # If no weak areas, recommend all videos
             return available_videos
 
-        # Simple keyword matching for video recommendations
         recommended = []
-
         for video in available_videos:
             video_title = video.get("title", "").lower()
             video_description = video.get("description", "").lower()
             video_tags = [tag.lower() for tag in video.get("tags", [])]
 
-            # Check if video content matches weak areas
             for weak_area in weak_areas:
                 weak_area_lower = weak_area.lower()
-
                 if (
                     weak_area_lower in video_title
                     or weak_area_lower in video_description
                     or any(weak_area_lower in tag for tag in video_tags)
                 ):
-
                     if video not in recommended:
                         recommended.append(video)
                     break
 
-        return (
-            recommended if recommended else available_videos[:3]
-        )  # Fallback to first 3 videos
+        return recommended if recommended else available_videos[:3]
 
-    # ============================================================================
+    # =======================================================================
     # REMEDIAL QUIZ GENERATION
-    # ============================================================================
+    # =======================================================================
 
     def generate_remedial_quiz(
         self,
@@ -659,37 +525,27 @@ Keep the response concise and student-friendly.
         if not question_pool:
             return []
 
-        # Identify topics from wrong answers
         weak_topics = set()
         for wrong_index in wrong_answers:
             if wrong_index < len(original_questions):
-                topic = original_questions[wrong_index].get("topic", "")
-                if topic:
-                    weak_topics.add(topic.lower())
+                tags = original_questions[wrong_index].get("tags", [])
+                for tag in tags or []:
+                    weak_topics.add(str(tag).lower())
 
-        # Filter question pool for remedial topics
         remedial_questions = []
-
         for question in question_pool:
-            question_topic = question.get("topic", "").lower()
-            question_tags = [tag.lower() for tag in question.get("tags", [])]
-
-            # Check if question matches weak topics
-            if question_topic in weak_topics or any(
-                tag in weak_topics for tag in question_tags
-            ):
+            question_tags = [str(tag).lower() for tag in question.get("tags", [])]
+            if weak_topics.intersection(question_tags):
                 remedial_questions.append(question)
 
-        # If no specific matches, use random questions from pool
         if not remedial_questions:
-            remedial_questions = question_pool[:5]  # Fallback to first 5 questions
+            remedial_questions = question_pool[:5]
 
-        # Limit to reasonable number of questions
         return remedial_questions[: min(len(remedial_questions), 5)]
 
-    # ============================================================================
+    # =======================================================================
     # CONTENT GENERATION HELPERS
-    # ============================================================================
+    # =======================================================================
 
     def generate_lesson_suggestions(
         self, subject: str, subtopic: str, current_lessons: List[Dict]
@@ -704,9 +560,7 @@ Analyze the existing lessons for {subject} - {subtopic} and suggest improvements
 Existing Lessons:
 """
 
-        for i, lesson in enumerate(
-            current_lessons[:5]
-        ):  # Limit to first 5 for prompt size
+        for i, lesson in enumerate(current_lessons[:5]):
             prompt += f"{i+1}. {lesson.get('title', 'Untitled')}\n"
 
         prompt += """
@@ -745,7 +599,7 @@ Respond with a brief assessment and specific recommendations.
         feedback = self.call_openai_api(prompt)
 
         return {
-            "valid": True,  # Assume valid unless obvious issues
+            "valid": True,
             "feedback": feedback,
-            "suggestions": [],  # Could be parsed from feedback if needed
+            "suggestions": [],
         }

--- a/self-paced-learning/services/progress_service.py
+++ b/self-paced-learning/services/progress_service.py
@@ -224,6 +224,9 @@ class ProgressService:
             "recommendations",
             "allowed_tags",
             "used_ai",
+            "analysis_stage",
+            "basic_feedback",
+            "rule_based_insights",
         ]
 
         sanitized = {key: analysis.get(key) for key in keys_to_keep if key in analysis}

--- a/self-paced-learning/services/quiz_analysis_utils.py
+++ b/self-paced-learning/services/quiz_analysis_utils.py
@@ -1,0 +1,265 @@
+"""Utility helpers for rule-based quiz analysis and scoring."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+_ALLOWED_TAG_CACHE: Dict[str, List[str]] = {}
+
+
+def _get_allowed_tags(subject: str, data_service: Optional[Any]) -> List[str]:
+    """Return allowed tags for a subject using a small in-memory cache."""
+    if not subject:
+        return []
+    cache_key = subject.lower()
+    if cache_key in _ALLOWED_TAG_CACHE:
+        return _ALLOWED_TAG_CACHE[cache_key]
+    if not data_service:
+        return []
+    try:
+        tags = data_service.get_subject_allowed_tags(subject) or []
+    except Exception:
+        tags = []
+    normalized = [str(tag).strip() for tag in tags if isinstance(tag, str) and str(tag).strip()]
+    _ALLOWED_TAG_CACHE[cache_key] = normalized
+    return normalized
+
+
+def resolve_correct_answer(question: Dict[str, Any]) -> str:
+    """Return the canonical correct answer text for a question."""
+    if not isinstance(question, dict):
+        return ""
+    if "correct_answer" in question and question["correct_answer"] is not None:
+        return str(question.get("correct_answer", ""))
+    if "answer" in question and question["answer"] is not None:
+        return str(question.get("answer", ""))
+    answer_index = question.get("answer_index")
+    options = question.get("options")
+    if isinstance(answer_index, int) and isinstance(options, Sequence) and 0 <= answer_index < len(options):
+        value = options[answer_index]
+        if isinstance(value, dict):
+            value = value.get("text") or value.get("value")
+        return str(value) if value is not None else ""
+    acceptable = question.get("acceptable_answers") or question.get("correct_answers")
+    if isinstance(acceptable, (list, tuple)) and acceptable:
+        return str(acceptable[0])
+    return ""
+
+
+def is_answer_correct(question: Dict[str, Any], user_answer: str) -> bool:
+    """Return True if the supplied answer should be considered correct."""
+    if not isinstance(question, dict):
+        return False
+    question_type = str(question.get("type", "multiple_choice")).strip().lower()
+    answer_text = resolve_correct_answer(question)
+    user_clean = (user_answer or "").strip()
+    if not user_clean:
+        return False
+    if question_type == "multiple_choice":
+        return user_clean == answer_text.strip()
+    if question_type == "fill_in_the_blank":
+        acceptable: List[str] = []
+        if answer_text:
+            acceptable.extend(
+                [part.strip().lower() for part in answer_text.split(",") if part.strip()]
+            )
+        raw_list = question.get("correct_answers") or question.get("acceptable_answers")
+        if isinstance(raw_list, (list, tuple)):
+            acceptable.extend([str(item).strip().lower() for item in raw_list if str(item).strip()])
+        return user_clean.lower() in acceptable if acceptable else False
+    if question_type == "coding":
+        # Coding questions require AI/manual review in basic flow
+        return False
+    return user_clean.lower() == answer_text.strip().lower()
+
+
+def collect_question_tags(question: Dict[str, Any]) -> List[str]:
+    """Gather all tags/topics defined on a question."""
+    tags: List[str] = []
+    if not isinstance(question, dict):
+        return tags
+    raw_tags = question.get("tags")
+    if isinstance(raw_tags, list):
+        tags.extend(str(tag) for tag in raw_tags if isinstance(tag, (str, int)))
+    elif isinstance(raw_tags, (str, int)):
+        tags.append(str(raw_tags))
+    topic = question.get("topic")
+    if isinstance(topic, list):
+        tags.extend(str(tag) for tag in topic if isinstance(tag, (str, int)))
+    elif isinstance(topic, (str, int)):
+        tags.append(str(topic))
+    return tags
+
+
+def normalize_tags(tags: Iterable[str]) -> List[str]:
+    """Normalize tags by trimming whitespace and removing duplicates."""
+    normalized: List[str] = []
+    seen = set()
+    for tag in tags or []:
+        if not isinstance(tag, str):
+            continue
+        cleaned = tag.strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(cleaned)
+    return normalized
+
+
+def filter_allowed_tags(tags: Iterable[str], allowed_lookup: Dict[str, str]) -> List[str]:
+    """Filter tags against allowed lookup, preserving order and casing."""
+    if not allowed_lookup:
+        return normalize_tags(tags)
+    filtered: List[str] = []
+    seen = set()
+    for tag in tags or []:
+        if not isinstance(tag, str):
+            continue
+        cleaned = tag.strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key not in allowed_lookup or key in seen:
+            continue
+        seen.add(key)
+        filtered.append(allowed_lookup[key])
+    return filtered
+
+
+def _apply_rule_based_topics(
+    question: Dict[str, Any],
+    is_correct: bool,
+    detected_tags: List[str],
+) -> List[str]:
+    """Augment detected tags with rule-based fallbacks."""
+    if is_correct:
+        return detected_tags
+    question_type = str(question.get("type", "")).strip().lower()
+    enriched = list(detected_tags)
+    if question_type == "coding":
+        enriched.append("programming logic")
+    difficulty = question.get("difficulty")
+    if isinstance(difficulty, str) and difficulty.lower() == "advanced":
+        enriched.append("advanced practice")
+    return enriched
+
+
+def _build_submission_detail(
+    index: int,
+    question: Dict[str, Any],
+    user_answer: str,
+    status: str,
+    correct_answer: str,
+) -> str:
+    parts = [
+        f"Question {index + 1} (Type: {str(question.get('type', 'multiple_choice')).title()}): {question.get('question', 'N/A')}",
+        "Student's Answer:",
+        "---",
+        user_answer if user_answer else "[No answer provided]",
+        "---",
+    ]
+    if correct_answer:
+        parts.append(f"Correct Answer: {correct_answer}")
+    parts.append(f"Status: {status}")
+    return "\n".join(parts) + "\n"
+
+
+def _generate_basic_feedback(score_percentage: int, weak_topics: List[str]) -> str:
+    if score_percentage >= 85:
+        base = "Excellent work! You're mastering this material."
+    elif score_percentage >= 70:
+        base = "Great job! A little more practice will make these concepts stick."
+    elif score_percentage >= 50:
+        base = "Good effort—target the topics below to boost your understanding."
+    else:
+        base = "Let's reinforce the fundamentals. Review the weak areas highlighted below."
+    if weak_topics:
+        topics_str = ", ".join(weak_topics[:5])
+        return f"{base} Focus on: {topics_str}."
+    return base
+
+
+def compute_basic_quiz_analysis(
+    questions: Sequence[Dict[str, Any]],
+    answers: Sequence[str],
+    subject: str,
+    subtopic: str,
+    data_service: Optional[Any] = None,
+    include_submission_details: bool = True,
+) -> Dict[str, Any]:
+    """Compute rule-based quiz analysis and scoring."""
+    total_questions = len(questions)
+    normalized_answers = [str(answer) if answer is not None else "" for answer in answers]
+    correct_answers = 0
+    wrong_indices: List[int] = []
+    wrong_tag_candidates: List[str] = []
+    weak_topic_details: List[Dict[str, Any]] = []
+    submission_details: List[str] = []
+
+    for idx, question in enumerate(questions):
+        user_answer = normalized_answers[idx] if idx < len(normalized_answers) else ""
+        status = "Incorrect"
+        if is_answer_correct(question, user_answer):
+            status = "Correct"
+            correct_answers += 1
+        else:
+            wrong_indices.append(idx)
+            detected = collect_question_tags(question)
+            enriched_tags = _apply_rule_based_topics(question, False, detected)
+            wrong_tag_candidates.extend(enriched_tags)
+            weak_topic_details.append(
+                {
+                    "question_index": idx,
+                    "question": question.get("question", ""),
+                    "tags": normalize_tags(enriched_tags),
+                    "type": question.get("type", "multiple_choice"),
+                }
+            )
+            if str(question.get("type", "")).strip().lower() == "coding" and not user_answer:
+                weak_topic_details[-1]["notes"] = "No code submitted for review."
+        if include_submission_details:
+            correct_answer = resolve_correct_answer(question)
+            submission_details.append(
+                _build_submission_detail(idx, question, user_answer, status, correct_answer)
+            )
+
+    percentage = int(round((correct_answers / total_questions) * 100)) if total_questions else 0
+    allowed_tags = _get_allowed_tags(subject, data_service)
+    allowed_lookup = {str(tag).lower(): str(tag) for tag in allowed_tags}
+    filtered_tags = filter_allowed_tags(wrong_tag_candidates, allowed_lookup)
+    if not filtered_tags:
+        filtered_tags = normalize_tags(wrong_tag_candidates)
+
+    feedback_message = _generate_basic_feedback(percentage, filtered_tags)
+    analysis_stage = "basic"
+
+    analysis: Dict[str, Any] = {
+        "score": {
+            "correct": correct_answers,
+            "total": total_questions,
+            "percentage": percentage,
+        },
+        "weak_topics": filtered_tags,
+        "weak_tags": filtered_tags,
+        "weak_areas": filtered_tags,
+        "feedback": feedback_message,
+        "ai_analysis": "",
+        "recommendations": [],
+        "submission_details": submission_details if include_submission_details else [],
+        "wrong_question_indices": wrong_indices,
+        "allowed_tags": allowed_tags,
+        "used_ai": False,
+        "analysis_stage": analysis_stage,
+        "basic_feedback": feedback_message,
+        "rule_based_insights": weak_topic_details,
+        "subject": subject,
+        "subtopic": subtopic,
+    }
+
+    if include_submission_details:
+        analysis["submission_preview"] = "".join(submission_details)[:500]
+
+    return analysis

--- a/self-paced-learning/static/css/styles.css
+++ b/self-paced-learning/static/css/styles.css
@@ -904,6 +904,122 @@ body.quiz-page {
   box-shadow: 0 8px 25px rgba(253, 203, 110, 0.3);
 }
 
+.analysis-progress-tracker {
+  display: flex;
+  gap: 12px;
+  margin: 15px 0;
+  flex-wrap: wrap;
+}
+
+.analysis-progress-tracker.hidden {
+  display: none;
+}
+
+.progress-pill {
+  background: #e5e7eb;
+  color: #374151;
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.progress-pill.completed {
+  background: #4f46e5;
+  color: #ffffff;
+}
+
+.progress-pill.completed::after {
+  content: "✓";
+  font-size: 0.8rem;
+}
+
+.progress-pill.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.ai-enhancement-banner {
+  margin: 10px 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #312e81;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.ai-enhancement-banner.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.ai-enhancement-banner.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.ai-enhancement-banner.hidden {
+  display: none;
+}
+
+.ai-feedback-skeleton {
+  margin: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-feedback-skeleton.hidden {
+  display: none;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    rgba(226, 232, 240, 0.6) 25%,
+    rgba(203, 213, 225, 0.9) 50%,
+    rgba(226, 232, 240, 0.6) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmerSkeleton 1.5s infinite;
+}
+
+.skeleton-line.wide {
+  width: 80%;
+}
+
+@keyframes shimmerSkeleton {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(99, 102, 241, 0.3);
+  border-top-color: #4f46e5;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* =================================================================
    Additional Results Page Styles (moved from inline styles)
    ================================================================= */

--- a/self-paced-learning/templates/quiz.html
+++ b/self-paced-learning/templates/quiz.html
@@ -93,6 +93,33 @@
       <button type="submit" class="quiz-submit-button">Submit Quiz</button>
     </form>
 
+    <div id="quiz-feedback-panel" class="quiz-feedback hidden">
+      <div class="quiz-feedback__score">
+        <div class="score-ring">
+          <span id="immediate-score">--%</span>
+        </div>
+        <p class="score-caption">Rule-based score</p>
+      </div>
+      <div class="quiz-feedback__details">
+        <p id="immediate-feedback" class="feedback-text">
+          Immediate feedback will appear here after submission.
+        </p>
+        <ul id="weak-topics-list" class="weak-topics-list"></ul>
+        <div id="analysis-progress" class="analysis-progress">
+          <span class="progress-chip" data-progress-step="score">Score</span>
+          <span class="progress-chip" data-progress-step="weak">Weak Areas</span>
+          <span class="progress-chip" data-progress-step="ai">AI Insights</span>
+        </div>
+        <div id="ai-status" class="ai-status">
+          <span class="spinner" aria-hidden="true"></span>
+          <span id="ai-status-text">Analyzing question patterns...</span>
+        </div>
+        <div id="redirect-notice" class="redirect-notice hidden">
+          Redirecting to detailed results...
+        </div>
+      </div>
+    </div>
+
     <script>
       // Add click handlers for visual feedback
       document.addEventListener("DOMContentLoaded", function () {
@@ -136,33 +163,127 @@
           }
 
           try {
-            // Submit answers to analyze route - Flask session will handle data persistence
             const analyzeResponse = await fetch("/analyze", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ answers: responses }),
             });
 
-            if (analyzeResponse.ok) {
-              // Analysis complete - redirect to results (data is in Flask session)
-              window.location.href = "/results";
-            } else {
-              console.error("Analysis failed:", analyzeResponse.status);
-              alert("Quiz analysis failed. Please try again.");
-              // Re-enable button on error
-              submitButton.disabled = false;
-              submitButton.textContent = originalText;
-              submitButton.classList.remove("disabled");
+            if (!analyzeResponse.ok) {
+              throw new Error(`Analysis failed with status ${analyzeResponse.status}`);
             }
+
+            const analyzePayload = await analyzeResponse.json();
+            if (!analyzePayload.success) {
+              throw new Error(analyzePayload.error || "Analysis request unsuccessful");
+            }
+
+            displayBasicAnalysis(analyzePayload.analysis || {});
+
+            // Kick off async enhancement (fire and forget)
+            try {
+              await fetch("/analyze/enhance", { method: "POST" });
+              setProgressState("ai");
+            } catch (enhanceError) {
+              console.warn("Unable to trigger AI enhancement:", enhanceError);
+              setAiStatus("AI enhancement unavailable. Showing basic results.", true);
+            }
+
+            redirectNotice.classList.remove("hidden");
+            redirectNotice.textContent = "Redirecting to detailed results...";
+
+            setTimeout(() => {
+              window.location.href = "/results";
+            }, 1500);
           } catch (error) {
             console.error("Error during analysis:", error);
-            alert("Error submitting quiz. Please try again.");
-            // Re-enable button on error
+            alert("Quiz analysis failed. Please try again.");
             submitButton.disabled = false;
             submitButton.textContent = originalText;
             submitButton.classList.remove("disabled");
+            feedbackPanel.classList.add("hidden");
           }
         });
+
+      const feedbackPanel = document.getElementById("quiz-feedback-panel");
+      const immediateScore = document.getElementById("immediate-score");
+      const immediateFeedback = document.getElementById("immediate-feedback");
+      const weakTopicsList = document.getElementById("weak-topics-list");
+      const progressChips = document.querySelectorAll(
+        ".progress-chip[data-progress-step]"
+      );
+      const aiStatusText = document.getElementById("ai-status-text");
+      const aiStatusContainer = document.getElementById("ai-status");
+      const redirectNotice = document.getElementById("redirect-notice");
+
+      function displayBasicAnalysis(analysis) {
+        if (!analysis) return;
+        feedbackPanel.classList.remove("hidden");
+        redirectNotice.classList.add("hidden");
+        setAiStatus("Analyzing question patterns...");
+        animateScore(analysis?.score?.percentage ?? 0);
+        immediateFeedback.textContent =
+          analysis.basic_feedback || analysis.feedback || "Great work!";
+        renderWeakTopics(analysis.weak_tags || analysis.weak_topics || []);
+        setProgressState("score");
+        setTimeout(() => setProgressState("weak"), 250);
+      }
+
+      function animateScore(targetScore) {
+        const start = 0;
+        const duration = 600;
+        const startTime = performance.now();
+
+        function update(now) {
+          const elapsed = now - startTime;
+          const progress = Math.min(elapsed / duration, 1);
+          const value = Math.round(start + (targetScore - start) * progress);
+          immediateScore.textContent = `${value}%`;
+          if (progress < 1) {
+            requestAnimationFrame(update);
+          } else {
+            setProgressState("weak");
+            setAiStatus("Enhancing analysis with AI...");
+          }
+        }
+
+        requestAnimationFrame(update);
+      }
+
+      function renderWeakTopics(topics) {
+        weakTopicsList.innerHTML = "";
+        if (!topics || topics.length === 0) {
+          const li = document.createElement("li");
+          li.textContent = "No weak areas detected. Great job!";
+          li.classList.add("all-clear");
+          weakTopicsList.appendChild(li);
+          return;
+        }
+
+        topics.slice(0, 5).forEach((topic) => {
+          const li = document.createElement("li");
+          li.textContent = topic;
+          weakTopicsList.appendChild(li);
+        });
+      }
+
+      function setProgressState(step) {
+        progressChips.forEach((chip) => {
+          const chipStep = chip.dataset.progressStep;
+          if (chipStep === step || chip.classList.contains("completed")) {
+            chip.classList.add("completed");
+          }
+        });
+      }
+
+      function setAiStatus(message, isWarning = false) {
+        aiStatusText.textContent = message;
+        if (isWarning) {
+          aiStatusContainer.classList.add("warning");
+        } else {
+          aiStatusContainer.classList.remove("warning");
+        }
+      }
 
       // Admin override functionality
       function toggleAdminOverride() {
@@ -295,6 +416,165 @@
       .admin-override-notice i {
         color: #ffc107;
         font-size: 1.2em;
+      }
+
+      .quiz-feedback {
+        margin-top: 30px;
+        padding: 20px;
+        border-radius: 16px;
+        background: #f4f6fb;
+        display: flex;
+        gap: 24px;
+        align-items: center;
+        box-shadow: 0 15px 45px rgba(15, 23, 42, 0.08);
+      }
+
+      .quiz-feedback.hidden {
+        display: none;
+      }
+
+      .quiz-feedback__score {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .score-ring {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        background: radial-gradient(circle at top, #4f46e5, #312e81);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 28px;
+        font-weight: 700;
+        box-shadow: inset 0 0 0 6px rgba(255, 255, 255, 0.2);
+      }
+
+      .score-caption {
+        font-size: 14px;
+        color: #4b5563;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+      }
+
+      .quiz-feedback__details {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .feedback-text {
+        font-size: 16px;
+        font-weight: 500;
+        color: #1f2937;
+      }
+
+      .weak-topics-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .weak-topics-list li {
+        background: #eef2ff;
+        color: #312e81;
+        padding: 6px 12px;
+        border-radius: 9999px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      .weak-topics-list li.all-clear {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .analysis-progress {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .progress-chip {
+        background: #e5e7eb;
+        color: #374151;
+        padding: 6px 14px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .progress-chip.completed {
+        background: #4f46e5;
+        color: #fff;
+      }
+
+      .progress-chip.completed::after {
+        content: "✓";
+        font-size: 12px;
+      }
+
+      .ai-status {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 14px;
+        color: #4b5563;
+      }
+
+      .ai-status.warning {
+        color: #b91c1c;
+      }
+
+      .spinner {
+        width: 16px;
+        height: 16px;
+        border: 2px solid rgba(99, 102, 241, 0.3);
+        border-top-color: #4f46e5;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+
+      .redirect-notice {
+        font-size: 13px;
+        color: #2563eb;
+        font-weight: 600;
+      }
+
+      .redirect-notice.hidden {
+        display: none;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (max-width: 768px) {
+        .quiz-feedback {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .score-ring {
+          width: 90px;
+          height: 90px;
+          font-size: 22px;
+        }
       }
 
       /* Disabled button styles */

--- a/self-paced-learning/templates/results.html
+++ b/self-paced-learning/templates/results.html
@@ -61,6 +61,26 @@
             </div>
           </div>
 
+          <div
+            id="analysis-progress-tracker"
+            class="analysis-progress-tracker hidden"
+          >
+            <span class="progress-pill" data-progress="score">Score</span>
+            <span class="progress-pill" data-progress="weak">Weak Areas</span>
+            <span class="progress-pill" data-progress="ai">AI Insights</span>
+          </div>
+
+          <div id="ai-enhancement-banner" class="ai-enhancement-banner hidden">
+            <span class="spinner" aria-hidden="true"></span>
+            <span id="ai-enhancement-text">Enhancing analysis with AI...</span>
+          </div>
+
+          <div id="ai-feedback-skeleton" class="ai-feedback-skeleton hidden">
+            <div class="skeleton-line wide"></div>
+            <div class="skeleton-line"></div>
+            <div class="skeleton-line"></div>
+          </div>
+
           {% if quiz_generation_error %}
           <div id="quiz-generation-error-message" class="status status-error">
             <strong>Error:</strong> {{ quiz_generation_error }}
@@ -91,6 +111,9 @@
       const CURRENT_SUBJECT = {{ CURRENT_SUBJECT | tojson | safe }};
       const CURRENT_SUBTOPIC = {{ CURRENT_SUBTOPIC | tojson | safe }};
       const ANALYSIS_RESULTS = {{ ANALYSIS_RESULTS | tojson | safe }};
+      const ENHANCEMENT_STATUS = {{ ENHANCEMENT_STATUS | tojson | safe }};
+      const HAS_ENHANCED = {{ HAS_ENHANCED | tojson | safe }};
+      const AI_AVAILABLE = {{ AI_AVAILABLE | tojson | safe }};
     </script>
 
     <script>
@@ -116,6 +139,22 @@
               const adminMarkCompleteButton = document.getElementById(
                 "adminMarkCompleteButton"
               );
+              const progressTracker = document.getElementById(
+                "analysis-progress-tracker"
+              );
+              const progressPills = document.querySelectorAll(
+                ".progress-pill"
+              );
+              const aiBanner = document.getElementById("ai-enhancement-banner");
+              const aiBannerText = document.getElementById(
+                "ai-enhancement-text"
+              );
+              const aiSkeleton = document.getElementById("ai-feedback-skeleton");
+
+              let enhancementPollingActive = false;
+              let initialRenderCompleted = false;
+              let currentAnalysis = ANALYSIS_RESULTS || {};
+              const aiAvailable = Boolean(AI_AVAILABLE);
 
               // --- State Tracking ---
               let completionState = {};
@@ -143,7 +182,8 @@
               statusDiv.textContent = "Analysis complete!";
               statusDiv.className = "status status-success";
 
-              await processAnalysisResults(ANALYSIS_RESULTS);
+              await processAnalysisResults(currentAnalysis);
+              configureEnhancementUI(ENHANCEMENT_STATUS);
 
               // --- Helper Functions ---
               function resolveLesson(keyOrId) {
@@ -221,7 +261,13 @@
               });
 
               // --- Analysis Results Processing Function ---
-              async function processAnalysisResults(analysisData) {
+              async function processAnalysisResults(
+                analysisData,
+                options = {}
+              ) {
+                if (!analysisData) return;
+
+                const { isEnhanced = false } = options;
                 console.log("Processing analysis results:", analysisData);
 
                 const weakTopics =
@@ -229,16 +275,23 @@
                     ? analysisData.weak_topics
                     : analysisData.weak_tags) || [];
 
-                // Calculate and display score
+                completionState = {};
+
                 if (analysisData.score) {
-                  displayScore(analysisData.score);
+                  displayScore(analysisData.score, {
+                    animate: !initialRenderCompleted,
+                  });
                 }
 
                 statusDiv.classList.add("hidden");
 
                 if (weakTopics.length > 0) {
                   welcomeMessageContainer.classList.remove("hidden");
-                  feedbackContentDiv.innerHTML = analysisData.feedback;
+                  masteryMessageContainer.classList.add("hidden");
+                  feedbackContentDiv.innerHTML =
+                    analysisData.feedback ||
+                    analysisData.ai_analysis ||
+                    "Focused practice recommendations will appear here.";
 
                   buildCompletionState(weakTopics);
                   displayWeakTopics(weakTopics);
@@ -247,12 +300,22 @@
                   backToTopicsButton.classList.remove("hidden");
                   checkCompletionAndToggleButton();
                 } else {
+                  topicsNavList.innerHTML = "";
+                  welcomeMessageContainer.classList.add("hidden");
                   masteryMessageContainer.classList.remove("hidden");
                   backToTopicsButton.classList.remove("hidden");
-                  // Show continue button for perfect scores too
                   continueButton.classList.remove("hidden");
-                  continueButton.disabled = false; // Enable button when no weak topics
+                  continueButton.disabled = false;
+                  updateProgress("weak");
                 }
+
+                if (isEnhanced) {
+                  updateProgress("ai");
+                  setAiBanner("AI insights ready!", "success");
+                  aiSkeleton.classList.add("hidden");
+                }
+
+                initialRenderCompleted = true;
               }
 
               // --- Simplified Topic Display ---
@@ -274,6 +337,8 @@
                  `;
                   topicsNavList.appendChild(groupLi);
                 });
+
+                updateProgress("weak");
               }
 
               // --- Helper Functions ---
@@ -284,15 +349,27 @@
               }
 
               // --- Score Display Function ---
-              function displayScore(scoreData) {
+              function displayScore(scoreData, options = {}) {
+                if (!scoreData) return;
                 const { correct, total, percentage } = scoreData;
+                const { animate = true } = options;
 
-                // Update score display
-                scoreDisplay.textContent = `${percentage}%`;
                 correctCount.textContent = correct;
                 totalCount.textContent = total;
 
-                // Apply score-based styling
+                applyScoreStyling(percentage);
+
+                if (animate) {
+                  animateScoreDisplay(percentage);
+                } else {
+                  scoreDisplay.textContent = `${Math.round(percentage)}%`;
+                }
+
+                scoreContainer.classList.remove("hidden");
+                updateProgress("score");
+              }
+
+              function applyScoreStyling(percentage) {
                 scoreContainer.classList.remove(
                   "score-excellent",
                   "score-good",
@@ -305,9 +382,158 @@
                 } else {
                   scoreContainer.classList.add("score-needs-improvement");
                 }
+              }
 
-                // Show the score container
-                scoreContainer.classList.remove("hidden");
+              function animateScoreDisplay(targetPercentage) {
+                const startValue = 0;
+                const duration = 800;
+                const startTime = performance.now();
+
+                function update(now) {
+                  const elapsed = now - startTime;
+                  const progress = Math.min(elapsed / duration, 1);
+                  const value = Math.round(
+                    startValue + (targetPercentage - startValue) * progress
+                  );
+                  scoreDisplay.textContent = `${value}%`;
+                  if (progress < 1) {
+                    requestAnimationFrame(update);
+                  }
+                }
+
+                requestAnimationFrame(update);
+              }
+
+              function updateProgress(step, variant = "completed") {
+                if (!progressTracker) return;
+                progressTracker.classList.remove("hidden");
+                progressPills.forEach((pill) => {
+                  if (pill.dataset.progress === step) {
+                    if (variant === "error") {
+                      pill.classList.add("error");
+                    } else {
+                      pill.classList.add("completed");
+                      pill.classList.remove("error");
+                    }
+                  }
+                });
+              }
+
+              function setAiBanner(message, variant = "loading") {
+                if (!aiBanner || !aiBannerText) return;
+                aiBannerText.textContent = message;
+                aiBanner.classList.remove("hidden", "success", "error");
+                const spinnerEl = aiBanner.querySelector(".spinner");
+                if (variant === "loading") {
+                  aiBanner.classList.remove("success", "error");
+                  if (spinnerEl) spinnerEl.style.display = "inline-block";
+                } else if (variant === "success") {
+                  aiBanner.classList.add("success");
+                  if (spinnerEl) spinnerEl.style.display = "none";
+                } else if (variant === "error") {
+                  aiBanner.classList.add("error");
+                  if (spinnerEl) spinnerEl.style.display = "none";
+                }
+              }
+
+              function configureEnhancementUI(status) {
+                if (!aiBanner || !progressTracker) return;
+                if (!aiAvailable) {
+                  progressTracker.classList.remove("hidden");
+                  aiBanner.classList.add("hidden");
+                  aiSkeleton.classList.add("hidden");
+                  return;
+                }
+
+                let normalizedStatus = (status || "").toString().toLowerCase();
+                if (
+                  (!normalizedStatus || normalizedStatus === "none") &&
+                  currentAnalysis &&
+                  currentAnalysis.analysis_stage === "enhanced"
+                ) {
+                  normalizedStatus = "completed";
+                }
+
+                if (normalizedStatus === "completed" || HAS_ENHANCED) {
+                  setAiBanner("AI insights ready!", "success");
+                  updateProgress("ai");
+                  aiSkeleton.classList.add("hidden");
+                } else if (normalizedStatus === "failed") {
+                  handleEnhancementFailure(
+                    "AI insights unavailable. Showing basic guidance."
+                  );
+                } else {
+                  aiBanner.classList.remove("hidden");
+                  aiSkeleton.classList.remove("hidden");
+                  setAiBanner("Enhancing analysis with AI...", "loading");
+                  if (!enhancementPollingActive) {
+                    enhancementPollingActive = true;
+                    startEnhancementPolling(normalizedStatus);
+                  }
+                }
+              }
+
+              function handleEnhancementFailure(message) {
+                setAiBanner(message || "AI enhancement unavailable.", "error");
+                updateProgress("ai", "error");
+                aiSkeleton.classList.add("hidden");
+              }
+
+              function startEnhancementPolling(initialStatus) {
+                if (!aiAvailable) return;
+                const allowedStatuses = [
+                  "pending",
+                  "in_progress",
+                  "basic",
+                  "basic_ready",
+                ];
+                if (!allowedStatuses.includes(initialStatus)) {
+                  return;
+                }
+
+                let attempts = 0;
+                const maxAttempts = 10;
+                const intervalMs = 2500;
+
+                const poll = async () => {
+                  attempts += 1;
+                  try {
+                    const response = await fetch("/analyze/enhance");
+                    if (!response.ok) {
+                      throw new Error(`Status ${response.status}`);
+                    }
+                    const payload = await response.json();
+                    if (payload.status === "completed" && payload.analysis) {
+                      currentAnalysis = payload.analysis;
+                      await processAnalysisResults(currentAnalysis, {
+                        isEnhanced: true,
+                      });
+                      configureEnhancementUI("completed");
+                      return;
+                    }
+                    if (payload.status === "failed") {
+                      handleEnhancementFailure(payload.error);
+                      return;
+                    }
+                    if (payload.status === "error") {
+                      handleEnhancementFailure(payload.error);
+                      return;
+                    }
+                  } catch (error) {
+                    console.error("Error polling enhancement:", error);
+                  }
+
+                  if (attempts >= maxAttempts) {
+                    handleEnhancementFailure(
+                      "AI enhancement timed out. Showing basic guidance."
+                    );
+                    return;
+                  }
+
+                  setTimeout(poll, intervalMs);
+                };
+
+                setTimeout(poll, intervalMs);
               }
 
               // --- Score Display Function (duplicate click handler removed) ---


### PR DESCRIPTION
## Summary
- add a dedicated rule-based quiz analysis utility and reuse it across the application
- update the analyze flow and AI service to return immediate feedback, warm caches, and perform background enhancements with retries and caching
- refresh the quiz and results interfaces (plus shared styling) to show progressive progress indicators, AI polling, and skeleton states while waiting for enhancements

## Testing
- pytest *(fails: known project fixtures expect DataService() without arguments and service integration route returns 403)*
- flake8 *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e079020708832f882e07ad213206b8