### PR TITLE
Improve code runner accessibility cues

### DIFF
--- a/self-paced-learning/static/css/styles.css
+++ b/self-paced-learning/static/css/styles.css
@@ -1230,207 +1230,391 @@ body.quiz-page {
 
 /* Code Runner Styles */
 .code-runner-block {
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-  border-radius: 8px;
-  margin: 20px 0;
+  position: relative;
+  margin: 24px 0;
+  border-radius: 16px;
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    linear-gradient(135deg, rgba(102, 126, 234, 0.4), rgba(118, 75, 162, 0.6))
+      border-box;
+  border: 1px solid transparent;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
   overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.code-runner-block:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 55px rgba(15, 23, 42, 0.16);
 }
 
 .code-runner-header {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  color: white;
-  padding: 12px 16px;
-  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 22px;
+  background: linear-gradient(135deg, #0f172a, #1f2937);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  color: #e2e8f0;
+  justify-content: space-between;
 }
 
 .code-runner-header h4 {
   margin: 0;
-  font-size: 1.1em;
-  color: white !important;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: inherit !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.code-runner-header i {
-  color: #ffd700;
-  margin-right: 8px;
+.code-runner-header h4 i {
+  color: #60a5fa;
+  font-size: 1.25rem;
+  text-shadow: 0 8px 20px rgba(96, 165, 250, 0.35);
+}
+
+.code-runner-toggle {
+  margin-left: auto;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.35);
+  color: #f1f5f9;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease, background 0.2s ease;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
+}
+
+.code-runner-toggle:hover,
+.code-runner-toggle:focus {
+  background: rgba(37, 99, 235, 0.35);
+  border-color: rgba(96, 165, 250, 0.75);
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(30, 64, 175, 0.45);
+}
+
+.code-runner-toggle i {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.code-runner-toggle.is-expanded {
+  background: rgba(12, 74, 110, 0.55);
+  border-color: rgba(125, 211, 252, 0.75);
+  color: #e0f2fe;
+  box-shadow: 0 18px 38px rgba(8, 47, 73, 0.55);
 }
 
 .code-runner-content {
-  padding: 16px;
+  padding: 24px;
+  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.08),
+        transparent 55%),
+    radial-gradient(circle at bottom right, rgba(148, 163, 184, 0.08),
+        transparent 50%),
+    #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .code-editor {
-  margin-bottom: 12px;
+  position: relative;
+}
+
+.code-editor::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  pointer-events: none;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
 }
 
 .python-editor {
   width: 100%;
-  min-height: 120px;
-  font-family: "Consolas", "Monaco", "Courier New", monospace;
-  font-size: 14px;
-  border: 1px solid #ced4da;
-  border-radius: 4px;
-  padding: 12px;
+  min-height: 140px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: linear-gradient(180deg, #0f172a, #111827);
+  color: #e2e8f0;
+  font-family: "JetBrains Mono", "Fira Code", "Consolas", "Monaco",
+    "Courier New", monospace;
+  font-size: 0.93rem;
+  line-height: 1.55;
+  padding: 20px;
   resize: vertical;
-  background-color: #f8f9fa;
-  line-height: 1.4;
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.2),
+    0 12px 30px rgba(15, 23, 42, 0.2);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
 }
 
 .python-editor:focus {
   outline: none;
-  border-color: #667eea;
-  box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
+  border-color: rgba(99, 102, 241, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.35),
+    0 18px 38px rgba(79, 70, 229, 0.28);
+  transform: translateY(-1px);
 }
 
 .code-controls {
   display: flex;
-  gap: 8px;
-  margin-bottom: 16px;
   flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.04);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(8px);
 }
 
 .run-code-btn,
 .clear-output-btn,
 .show-solution-btn,
-.show-hints-btn,
-.expand-code-btn {
-  background: #667eea;
-  color: white;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  transition: background-color 0.2s;
-  display: flex;
+.show-hints-btn {
+  position: relative;
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background 0.2s ease, border-color 0.2s ease;
+  color: #0f172a;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.18),
+      rgba(59, 130, 246, 0.45));
+  box-shadow: 0 12px 25px rgba(148, 163, 184, 0.28);
+}
+
+.run-code-btn:hover,
+.clear-output-btn:hover,
+.show-solution-btn:hover,
+.show-hints-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.25);
+}
+
+.run-code-btn {
+  color: #0f172a;
+  background: linear-gradient(135deg, #60a5fa, #3b82f6);
+  border-color: rgba(37, 99, 235, 0.3);
+  box-shadow: 0 14px 32px rgba(59, 130, 246, 0.35);
 }
 
 .run-code-btn:hover {
-  background: #5a67d8;
+  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.38);
 }
 
 .clear-output-btn {
-  background: #6c757d;
+  background: linear-gradient(135deg, #e2e8f0, #cbd5f5);
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 14px 30px rgba(148, 163, 184, 0.25);
 }
 
 .clear-output-btn:hover {
-  background: #5a6268;
+  box-shadow: 0 18px 36px rgba(148, 163, 184, 0.28);
 }
 
 .show-solution-btn {
-  background: #28a745;
-}
-
-.show-solution-btn:hover {
-  background: #218838;
+  background: linear-gradient(135deg, #a7f3d0, #34d399);
+  border-color: rgba(16, 185, 129, 0.35);
+  box-shadow: 0 14px 32px rgba(45, 212, 191, 0.35);
 }
 
 .show-hints-btn {
-  background: #ffc107;
-  color: #212529;
-}
-
-.show-hints-btn:hover {
-  background: #e0a800;
-}
-
-.expand-code-btn {
-  background: #17a2b8;
-}
-
-.expand-code-btn:hover {
-  background: #138496;
+  background: linear-gradient(135deg, #fde68a, #f59e0b);
+  color: #78350f;
+  border-color: rgba(217, 119, 6, 0.35);
+  box-shadow: 0 14px 32px rgba(245, 158, 11, 0.28);
 }
 
 .run-code-btn:disabled {
-  background: #6c757d;
+  opacity: 0.65;
   cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .code-output {
-  background: #343a40;
-  border-radius: 4px;
-  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.5);
+  background: linear-gradient(180deg, #0f172a, #020617);
+  box-shadow: inset 0 0 0 1px rgba(30, 64, 175, 0.3),
+    0 18px 45px rgba(8, 47, 73, 0.4);
 }
 
 .output-header {
-  background: #495057;
-  color: white;
-  padding: 8px 12px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.6),
+      rgba(37, 99, 235, 0.35));
+  color: #e0f2fe;
+  padding: 12px 18px;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 0.95rem;
+  letter-spacing: 0.03em;
 }
 
 .output-content {
-  padding: 12px;
-  background: #343a40 !important;
-  color: #f8f9fa !important;
-  font-family: "Consolas", "Monaco", "Courier New", monospace;
-  font-size: 14px;
-  min-height: 60px;
+  padding: 20px;
   margin: 0;
+  color: #e2e8f0 !important;
+  background: transparent !important;
+  font-family: "JetBrains Mono", "Fira Code", "Consolas", "Monaco",
+    "Courier New", monospace;
+  font-size: 0.92rem;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  word-break: break-word;
+  min-height: 80px;
 }
 
 .output-content.success {
-  border-left: 4px solid #28a745;
+  border-left: 4px solid rgba(34, 197, 94, 0.8);
 }
 
 .output-content.error {
-  border-left: 4px solid #dc3545;
-  background: #343a40 !important;
-  color: #ff6b6b !important;
+  border-left: 4px solid rgba(239, 68, 68, 0.9);
+  color: #fda4af !important;
 }
 
 .expected-output,
 .hints-content,
 .solution-content {
-  background: #e9ecef;
-  border-radius: 4px;
-  padding: 12px;
-  margin-top: 12px;
+  border-radius: 14px;
+  padding: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.18);
 }
 
-.expected-output pre,
+.expected-output {
+  background: linear-gradient(135deg, #dbeafe, #bfdbfe);
+  border-color: rgba(59, 130, 246, 0.35);
+  color: #0f172a;
+}
+
+.expected-output strong {
+  color: #1d4ed8;
+}
+
+.expected-output pre {
+  background: #eff6ff;
+  color: #0f172a;
+  padding: 14px;
+  border-radius: 10px;
+  margin: 10px 0 0 0;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  font-family: "JetBrains Mono", "Fira Code", "Consolas", "Monaco",
+    "Courier New", monospace;
+  font-size: 0.9rem;
+}
+
+.hints-content {
+  background: linear-gradient(135deg, #fef3c7, #fde68a);
+  border-color: rgba(217, 119, 6, 0.35);
+  color: #7c2d12;
+}
+
+.hints-content strong {
+  color: #9a3412;
+}
+
+.solution-content {
+  background: linear-gradient(135deg, #ede9fe, #ddd6fe);
+  border-color: rgba(129, 140, 248, 0.45);
+  color: #312e81;
+}
+
+.solution-content strong {
+  color: #5b21b6;
+}
+
 .solution-content pre {
-  background: #f8f9fa;
-  padding: 8px;
-  border-radius: 4px;
-  margin: 8px 0 0 0;
-  font-family: "Consolas", "Monaco", "Courier New", monospace;
-  font-size: 14px;
+  background: #f5f3ff;
+  color: #312e81;
+  padding: 14px;
+  border-radius: 10px;
+  margin: 10px 0 0 0;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  font-family: "JetBrains Mono", "Fira Code", "Consolas", "Monaco",
+    "Courier New", monospace;
+  font-size: 0.9rem;
+}
+
+.solution-content pre code {
+  color: inherit;
+}
+
+.expected-output strong,
+.hints-content strong,
+.solution-content strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
 }
 
 .hints-content ul {
-  margin: 8px 0 0 0;
-  padding-left: 20px;
+  margin: 10px 0 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
 }
 
 .hints-content li {
-  margin-bottom: 4px;
+  margin: 0;
+  color: #7c2d12;
+  font-size: 0.92rem;
 }
 
 /* Responsive design for code runner */
 @media (max-width: 768px) {
+  .code-runner-header {
+    padding: 16px 18px;
+  }
+
+  .code-runner-toggle {
+    width: 38px;
+    height: 38px;
+  }
+
+  .code-runner-content {
+    padding: 20px;
+  }
+
+  .code-editor::after {
+    inset: 6px;
+  }
+
   .code-controls {
     flex-direction: column;
+    align-items: stretch;
   }
 
   .run-code-btn,
   .clear-output-btn,
   .show-solution-btn,
-  .show-hints-btn,
-  .expand-code-btn {
+  .show-hints-btn {
     width: 100%;
     justify-content: center;
   }
 
   .python-editor {
-    font-size: 13px;
+    font-size: 0.88rem;
+    padding: 18px;
   }
 }
 
@@ -1442,8 +1626,8 @@ body.quiz-page {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(5px);
+  background: rgba(2, 6, 23, 0.85);
+  backdrop-filter: blur(18px);
   z-index: 1000;
   justify-content: center;
   align-items: center;
@@ -1456,9 +1640,10 @@ body.quiz-page {
 }
 
 .code-runner-modal-content {
-  background: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.98),
+      rgba(17, 24, 39, 0.94));
+  border-radius: 24px;
+  box-shadow: 0 35px 90px rgba(15, 23, 42, 0.55);
   width: 70vw;
   max-width: 1280px;
   height: 85vh;
@@ -1468,22 +1653,26 @@ body.quiz-page {
   flex-direction: column;
   position: relative;
   overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .code-runner-modal-header {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  color: white;
-  padding: 16px 20px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.25),
+      rgba(79, 70, 229, 0.25));
+  color: #e2e8f0;
+  padding: 22px 28px;
   font-weight: 600;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .code-runner-modal-header h4 {
   margin: 0;
-  font-size: 1.2em;
-  color: white !important;
+  font-size: 1.15rem;
+  color: inherit !important;
+  letter-spacing: 0.02em;
 }
 
 .code-runner-modal-actions {
@@ -1493,51 +1682,58 @@ body.quiz-page {
 }
 
 .code-runner-modal-collapse {
-  background: rgba(255, 255, 255, 0.2);
-  border: none;
-  color: white;
-  border-radius: 6px;
-  padding: 8px 14px;
-  font-size: 0.9rem;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2),
+      rgba(96, 165, 250, 0.35));
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: #e0f2fe;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 0.88rem;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  transition: background 0.2s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 26px rgba(59, 130, 246, 0.25);
 }
 
 .code-runner-modal-collapse:hover {
-  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 34px rgba(37, 99, 235, 0.3);
 }
 
 .code-runner-modal-close {
-  background: rgba(255, 255, 255, 0.2);
-  border: none;
-  color: white;
-  width: 32px;
-  height: 32px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+  width: 38px;
+  height: 38px;
   border-radius: 50%;
   cursor: pointer;
   font-size: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.4);
 }
 
 .code-runner-modal-close:hover {
-  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.45);
 }
 
 .code-runner-modal-body {
   flex: 1;
-  padding: 24px;
+  padding: 28px;
   overflow-y: auto;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.6),
+      rgba(15, 23, 42, 0.3));
 }
 
 .code-runner-modal .python-editor {
-  min-height: 200px;
-  font-size: 15px;
+  min-height: 220px;
+  font-size: 0.95rem;
 }
 
 .code-runner-modal .code-output {
@@ -1546,21 +1742,21 @@ body.quiz-page {
 }
 
 .code-runner-modal-question {
-  background: #eef2ff;
-  border: 1px solid #d7dcfb;
-  border-radius: 10px;
-  padding: 16px 18px;
-  color: #2c3e50;
-  line-height: 1.6;
+  background: rgba(241, 245, 249, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 22px;
+  color: #0f172a;
+  line-height: 1.7;
   font-size: 0.95rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  box-shadow: 0 18px 38px rgba(148, 163, 184, 0.2);
 }
 
 .code-runner-modal-question h3,
 .code-runner-modal-question h4,
 .code-runner-modal-question h5 {
   margin-top: 0;
-  color: #4a3b8f;
+  color: #312e81;
 }
 
 .code-runner-modal-question p {
@@ -1571,7 +1767,7 @@ body.quiz-page {
 .code-runner-content.code-runner-expanded {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
   height: 100%;
   min-height: 0;
 }
@@ -1583,15 +1779,16 @@ body.quiz-page {
 .code-runner-content.code-runner-expanded .code-controls {
   position: sticky;
   top: 12px;
-  background: #ffffff;
-  padding: 12px 14px;
-  border-radius: 8px;
-  box-shadow: 0 10px 24px rgba(102, 126, 234, 0.14);
-  border: 1px solid rgba(102, 126, 234, 0.18);
+  background: rgba(15, 23, 42, 0.08);
+  padding: 16px 18px;
+  border-radius: 18px;
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(10px);
   z-index: 2;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 12px;
 }
 
 .code-runner-expanded-grid {
@@ -1650,11 +1847,11 @@ body.quiz-page {
 
 .code-runner-modal-expected {
   grid-area: expected;
-  background: #f6f8ff;
-  border: 1px solid #d9def9;
-  border-radius: 10px;
-  padding: 18px 20px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  background: rgba(241, 245, 249, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 16px;
+  padding: 22px;
+  box-shadow: 0 18px 38px rgba(148, 163, 184, 0.22);
   margin: 0;
 }
 
@@ -1678,7 +1875,7 @@ body.quiz-page {
 }
 
 .code-runner-grid-output .code-output {
-  border-radius: 10px;
+  border-radius: 16px;
   overflow: hidden;
   margin: 0;
   display: flex;
@@ -1710,10 +1907,10 @@ body.quiz-page {
 
 .code-runner-grid-output .hints-content,
 .code-runner-grid-output .solution-content {
-  background: #f6f8ff;
-  border: 1px solid #e1e6ff;
-  border-radius: 10px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  background: rgba(241, 245, 249, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 16px;
+  box-shadow: 0 18px 36px rgba(148, 163, 184, 0.18);
 }
 
 /* --------------------------------------------------------------------------- */

--- a/self-paced-learning/templates/python_subject.html
+++ b/self-paced-learning/templates/python_subject.html
@@ -1710,6 +1710,9 @@
                   <div class="code-runner-block" id="code-runner-${blockId}">
                     <div class="code-runner-header">
                       <h4><i class="fas fa-play-circle"></i> Interactive Python Code</h4>
+                      <button class="code-runner-toggle" type="button" onclick="expandCodeRunner('${blockId}')" aria-expanded="false" aria-label="Expand code runner">
+                        <i class="fas fa-expand-alt"></i>
+                      </button>
                     </div>
                     <div class="code-runner-content">
                       <div class="code-editor">
@@ -1735,9 +1738,6 @@
                             ? `<button class="show-hints-btn" onclick="showHints('${blockId}')"><i class="fas fa-question-circle"></i> Show Hints</button>`
                             : ""
                         }
-                        <button class="expand-code-btn" onclick="expandCodeRunner('${blockId}')" aria-expanded="false">
-                          <i class="fas fa-expand"></i> Expand
-                        </button>
                       </div>
                       <div class="code-output">
                         <div class="output-header">Output:</div>
@@ -2996,21 +2996,23 @@ sys.stdout = StringIO()
       }
 
       function setExpandButtonState(blockId, isExpanded) {
-        const expandBtn = document.querySelector(
-          `#code-runner-${blockId} .expand-code-btn`
+        const toggleBtn = document.querySelector(
+          `#code-runner-${blockId} .code-runner-toggle`
         );
 
-        if (!expandBtn) {
+        if (!toggleBtn) {
           return;
         }
 
-        expandBtn.innerHTML = isExpanded
-          ? '<i class="fas fa-compress"></i> Collapse'
-          : '<i class="fas fa-expand"></i> Expand';
-        expandBtn.setAttribute("aria-expanded", isExpanded ? "true" : "false");
-        expandBtn.setAttribute("aria-hidden", isExpanded ? "true" : "false");
-        expandBtn.style.display = isExpanded ? "none" : "inline-flex";
-        expandBtn.disabled = isExpanded;
+        toggleBtn.innerHTML = isExpanded
+          ? '<i class="fas fa-compress-alt"></i>'
+          : '<i class="fas fa-expand-alt"></i>';
+        toggleBtn.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+        toggleBtn.setAttribute(
+          "aria-label",
+          isExpanded ? "Collapse code runner" : "Expand code runner"
+        );
+        toggleBtn.classList.toggle("is-expanded", isExpanded);
       }
 
       function collectCodeRunnerQuestion(originalBlock) {

--- a/self-paced-learning/templates/results.html
+++ b/self-paced-learning/templates/results.html
@@ -543,6 +543,9 @@
                       <div class="code-runner-block" id="code-runner-${blockId}">
                         <div class="code-runner-header">
                           <h4><i class="fas fa-play-circle"></i> Interactive Python Code</h4>
+                          <button class="code-runner-toggle" type="button" onclick="toggleCodeRunner('${blockId}')" aria-expanded="false" aria-label="Expand code runner">
+                            <i class="fas fa-expand-alt"></i>
+                          </button>
                         </div>
                         <div class="code-runner-content">
                           <div class="code-editor">
@@ -557,9 +560,6 @@
                             </button>
                             ${item.solution ? `<button class="show-solution-btn" onclick="showSolution('${blockId}')"><i class="fas fa-lightbulb"></i> Show Solution</button>` : ''}
                             ${item.hints && item.hints.length > 0 ? `<button class="show-hints-btn" onclick="showHints('${blockId}')"><i class="fas fa-question-circle"></i> Show Hints</button>` : ''}
-                            <button class="expand-code-btn" onclick="expandCodeRunner('${blockId}')">
-                              <i class="fas fa-expand"></i> Expand
-                            </button>
                           </div>
                           <div class="code-output">
                             <div class="output-header">Output:</div>
@@ -863,6 +863,46 @@
             });
 
             // Modal functions for expanding code runners
+            let activeCodeRunnerId = null;
+
+            function setExpandButtonState(blockId, isExpanded) {
+              const toggleButton = document.querySelector(
+                `#code-runner-${blockId} .code-runner-toggle`
+              );
+
+              if (!toggleButton) return;
+
+              toggleButton.setAttribute(
+                "aria-expanded",
+                isExpanded ? "true" : "false"
+              );
+              toggleButton.setAttribute(
+                "aria-label",
+                isExpanded ? "Collapse code runner" : "Expand code runner"
+              );
+              toggleButton.classList.toggle("is-expanded", isExpanded);
+              toggleButton.innerHTML = isExpanded
+                ? '<i class="fas fa-compress-alt"></i>'
+                : '<i class="fas fa-expand-alt"></i>';
+            }
+
+            function toggleCodeRunner(blockId) {
+              const modal = document.getElementById("code-runner-modal");
+              const isActive =
+                modal &&
+                modal.classList.contains("active") &&
+                activeCodeRunnerId === blockId;
+
+              if (isActive) {
+                closeCodeRunnerModal();
+              } else {
+                if (activeCodeRunnerId && activeCodeRunnerId !== blockId) {
+                  closeCodeRunnerModal();
+                }
+                expandCodeRunner(blockId);
+              }
+            }
+
             function expandCodeRunner(blockId) {
               const originalContainer = document.getElementById(`code-runner-${blockId}`);
               if (!originalContainer) return;
@@ -951,6 +991,8 @@
 
               // Show modal
               modal.classList.add('active');
+              activeCodeRunnerId = blockId;
+              setExpandButtonState(blockId, true);
 
               // Focus on textarea
               setTimeout(() => {
@@ -963,12 +1005,18 @@
 
             function closeCodeRunnerModal() {
               const modal = document.getElementById('code-runner-modal');
-              if (!modal) return;
+              if (!modal || !modal.classList.contains('active')) {
+                return;
+              }
 
               // Sync content back before closing
               syncFromModal();
 
               modal.classList.remove('active');
+              if (activeCodeRunnerId) {
+                setExpandButtonState(activeCodeRunnerId, false);
+              }
+              activeCodeRunnerId = null;
             }
 
             function syncToModal(blockId) {


### PR DESCRIPTION
## Summary
- relocate the code runner expand control to a header toggle that switches between expand and collapse icons while preserving modal behavior
- refresh expected output, hints, and solution surfaces with higher-contrast palettes for clearer readability across states

## Testing
- pytest *(fails: DataService.__init__ requires data_root_path in tests/quick_test.py; KeyError on sample video data in tests/test_features_comprehensive.py; 403 on /dev/test-services route in tests/test_routes_comprehensive.py)*
- flake8 *(not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e07a69cd00832fb72c7857d68c37b4