### PR TITLE
Ensure AI fallback retains feedback metadata

### DIFF
--- a/self-paced-learning/services/progress_service.py
+++ b/self-paced-learning/services/progress_service.py
@@ -224,6 +224,9 @@ class ProgressService:
             "recommendations",
             "allowed_tags",
             "used_ai",
+            "analysis_stage",
+            "basic_feedback",
+            "rule_based_insights",
         ]
 
         sanitized = {key: analysis.get(key) for key in keys_to_keep if key in analysis}

--- a/self-paced-learning/services/quiz_analysis_utils.py
+++ b/self-paced-learning/services/quiz_analysis_utils.py
@@ -1,0 +1,265 @@
+"""Utility helpers for rule-based quiz analysis and scoring."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+_ALLOWED_TAG_CACHE: Dict[str, List[str]] = {}
+
+
+def _get_allowed_tags(subject: str, data_service: Optional[Any]) -> List[str]:
+    """Return allowed tags for a subject using a small in-memory cache."""
+    if not subject:
+        return []
+    cache_key = subject.lower()
+    if cache_key in _ALLOWED_TAG_CACHE:
+        return _ALLOWED_TAG_CACHE[cache_key]
+    if not data_service:
+        return []
+    try:
+        tags = data_service.get_subject_allowed_tags(subject) or []
+    except Exception:
+        tags = []
+    normalized = [str(tag).strip() for tag in tags if isinstance(tag, str) and str(tag).strip()]
+    _ALLOWED_TAG_CACHE[cache_key] = normalized
+    return normalized
+
+
+def resolve_correct_answer(question: Dict[str, Any]) -> str:
+    """Return the canonical correct answer text for a question."""
+    if not isinstance(question, dict):
+        return ""
+    if "correct_answer" in question and question["correct_answer"] is not None:
+        return str(question.get("correct_answer", ""))
+    if "answer" in question and question["answer"] is not None:
+        return str(question.get("answer", ""))
+    answer_index = question.get("answer_index")
+    options = question.get("options")
+    if isinstance(answer_index, int) and isinstance(options, Sequence) and 0 <= answer_index < len(options):
+        value = options[answer_index]
+        if isinstance(value, dict):
+            value = value.get("text") or value.get("value")
+        return str(value) if value is not None else ""
+    acceptable = question.get("acceptable_answers") or question.get("correct_answers")
+    if isinstance(acceptable, (list, tuple)) and acceptable:
+        return str(acceptable[0])
+    return ""
+
+
+def is_answer_correct(question: Dict[str, Any], user_answer: str) -> bool:
+    """Return True if the supplied answer should be considered correct."""
+    if not isinstance(question, dict):
+        return False
+    question_type = str(question.get("type", "multiple_choice")).strip().lower()
+    answer_text = resolve_correct_answer(question)
+    user_clean = (user_answer or "").strip()
+    if not user_clean:
+        return False
+    if question_type == "multiple_choice":
+        return user_clean == answer_text.strip()
+    if question_type == "fill_in_the_blank":
+        acceptable: List[str] = []
+        if answer_text:
+            acceptable.extend(
+                [part.strip().lower() for part in answer_text.split(",") if part.strip()]
+            )
+        raw_list = question.get("correct_answers") or question.get("acceptable_answers")
+        if isinstance(raw_list, (list, tuple)):
+            acceptable.extend([str(item).strip().lower() for item in raw_list if str(item).strip()])
+        return user_clean.lower() in acceptable if acceptable else False
+    if question_type == "coding":
+        # Coding questions require AI/manual review in basic flow
+        return False
+    return user_clean.lower() == answer_text.strip().lower()
+
+
+def collect_question_tags(question: Dict[str, Any]) -> List[str]:
+    """Gather all tags/topics defined on a question."""
+    tags: List[str] = []
+    if not isinstance(question, dict):
+        return tags
+    raw_tags = question.get("tags")
+    if isinstance(raw_tags, list):
+        tags.extend(str(tag) for tag in raw_tags if isinstance(tag, (str, int)))
+    elif isinstance(raw_tags, (str, int)):
+        tags.append(str(raw_tags))
+    topic = question.get("topic")
+    if isinstance(topic, list):
+        tags.extend(str(tag) for tag in topic if isinstance(tag, (str, int)))
+    elif isinstance(topic, (str, int)):
+        tags.append(str(topic))
+    return tags
+
+
+def normalize_tags(tags: Iterable[str]) -> List[str]:
+    """Normalize tags by trimming whitespace and removing duplicates."""
+    normalized: List[str] = []
+    seen = set()
+    for tag in tags or []:
+        if not isinstance(tag, str):
+            continue
+        cleaned = tag.strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(cleaned)
+    return normalized
+
+
+def filter_allowed_tags(tags: Iterable[str], allowed_lookup: Dict[str, str]) -> List[str]:
+    """Filter tags against allowed lookup, preserving order and casing."""
+    if not allowed_lookup:
+        return normalize_tags(tags)
+    filtered: List[str] = []
+    seen = set()
+    for tag in tags or []:
+        if not isinstance(tag, str):
+            continue
+        cleaned = tag.strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key not in allowed_lookup or key in seen:
+            continue
+        seen.add(key)
+        filtered.append(allowed_lookup[key])
+    return filtered
+
+
+def _apply_rule_based_topics(
+    question: Dict[str, Any],
+    is_correct: bool,
+    detected_tags: List[str],
+) -> List[str]:
+    """Augment detected tags with rule-based fallbacks."""
+    if is_correct:
+        return detected_tags
+    question_type = str(question.get("type", "")).strip().lower()
+    enriched = list(detected_tags)
+    if question_type == "coding":
+        enriched.append("programming logic")
+    difficulty = question.get("difficulty")
+    if isinstance(difficulty, str) and difficulty.lower() == "advanced":
+        enriched.append("advanced practice")
+    return enriched
+
+
+def _build_submission_detail(
+    index: int,
+    question: Dict[str, Any],
+    user_answer: str,
+    status: str,
+    correct_answer: str,
+) -> str:
+    parts = [
+        f"Question {index + 1} (Type: {str(question.get('type', 'multiple_choice')).title()}): {question.get('question', 'N/A')}",
+        "Student's Answer:",
+        "---",
+        user_answer if user_answer else "[No answer provided]",
+        "---",
+    ]
+    if correct_answer:
+        parts.append(f"Correct Answer: {correct_answer}")
+    parts.append(f"Status: {status}")
+    return "\n".join(parts) + "\n"
+
+
+def _generate_basic_feedback(score_percentage: int, weak_topics: List[str]) -> str:
+    if score_percentage >= 85:
+        base = "Excellent work! You're mastering this material."
+    elif score_percentage >= 70:
+        base = "Great job! A little more practice will make these concepts stick."
+    elif score_percentage >= 50:
+        base = "Good effort—target the topics below to boost your understanding."
+    else:
+        base = "Let's reinforce the fundamentals. Review the weak areas highlighted below."
+    if weak_topics:
+        topics_str = ", ".join(weak_topics[:5])
+        return f"{base} Focus on: {topics_str}."
+    return base
+
+
+def compute_basic_quiz_analysis(
+    questions: Sequence[Dict[str, Any]],
+    answers: Sequence[str],
+    subject: str,
+    subtopic: str,
+    data_service: Optional[Any] = None,
+    include_submission_details: bool = True,
+) -> Dict[str, Any]:
+    """Compute rule-based quiz analysis and scoring."""
+    total_questions = len(questions)
+    normalized_answers = [str(answer) if answer is not None else "" for answer in answers]
+    correct_answers = 0
+    wrong_indices: List[int] = []
+    wrong_tag_candidates: List[str] = []
+    weak_topic_details: List[Dict[str, Any]] = []
+    submission_details: List[str] = []
+
+    for idx, question in enumerate(questions):
+        user_answer = normalized_answers[idx] if idx < len(normalized_answers) else ""
+        status = "Incorrect"
+        if is_answer_correct(question, user_answer):
+            status = "Correct"
+            correct_answers += 1
+        else:
+            wrong_indices.append(idx)
+            detected = collect_question_tags(question)
+            enriched_tags = _apply_rule_based_topics(question, False, detected)
+            wrong_tag_candidates.extend(enriched_tags)
+            weak_topic_details.append(
+                {
+                    "question_index": idx,
+                    "question": question.get("question", ""),
+                    "tags": normalize_tags(enriched_tags),
+                    "type": question.get("type", "multiple_choice"),
+                }
+            )
+            if str(question.get("type", "")).strip().lower() == "coding" and not user_answer:
+                weak_topic_details[-1]["notes"] = "No code submitted for review."
+        if include_submission_details:
+            correct_answer = resolve_correct_answer(question)
+            submission_details.append(
+                _build_submission_detail(idx, question, user_answer, status, correct_answer)
+            )
+
+    percentage = int(round((correct_answers / total_questions) * 100)) if total_questions else 0
+    allowed_tags = _get_allowed_tags(subject, data_service)
+    allowed_lookup = {str(tag).lower(): str(tag) for tag in allowed_tags}
+    filtered_tags = filter_allowed_tags(wrong_tag_candidates, allowed_lookup)
+    if not filtered_tags:
+        filtered_tags = normalize_tags(wrong_tag_candidates)
+
+    feedback_message = _generate_basic_feedback(percentage, filtered_tags)
+    analysis_stage = "basic"
+
+    analysis: Dict[str, Any] = {
+        "score": {
+            "correct": correct_answers,
+            "total": total_questions,
+            "percentage": percentage,
+        },
+        "weak_topics": filtered_tags,
+        "weak_tags": filtered_tags,
+        "weak_areas": filtered_tags,
+        "feedback": feedback_message,
+        "ai_analysis": "",
+        "recommendations": [],
+        "submission_details": submission_details if include_submission_details else [],
+        "wrong_question_indices": wrong_indices,
+        "allowed_tags": allowed_tags,
+        "used_ai": False,
+        "analysis_stage": analysis_stage,
+        "basic_feedback": feedback_message,
+        "rule_based_insights": weak_topic_details,
+        "subject": subject,
+        "subtopic": subtopic,
+    }
+
+    if include_submission_details:
+        analysis["submission_preview"] = "".join(submission_details)[:500]
+
+    return analysis

--- a/self-paced-learning/static/css/styles.css
+++ b/self-paced-learning/static/css/styles.css
@@ -904,6 +904,122 @@ body.quiz-page {
   box-shadow: 0 8px 25px rgba(253, 203, 110, 0.3);
 }
 
+.analysis-progress-tracker {
+  display: flex;
+  gap: 12px;
+  margin: 15px 0;
+  flex-wrap: wrap;
+}
+
+.analysis-progress-tracker.hidden {
+  display: none;
+}
+
+.progress-pill {
+  background: #e5e7eb;
+  color: #374151;
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.progress-pill.completed {
+  background: #4f46e5;
+  color: #ffffff;
+}
+
+.progress-pill.completed::after {
+  content: "✓";
+  font-size: 0.8rem;
+}
+
+.progress-pill.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.ai-enhancement-banner {
+  margin: 10px 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #312e81;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.ai-enhancement-banner.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.ai-enhancement-banner.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.ai-enhancement-banner.hidden {
+  display: none;
+}
+
+.ai-feedback-skeleton {
+  margin: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-feedback-skeleton.hidden {
+  display: none;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    rgba(226, 232, 240, 0.6) 25%,
+    rgba(203, 213, 225, 0.9) 50%,
+    rgba(226, 232, 240, 0.6) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmerSkeleton 1.5s infinite;
+}
+
+.skeleton-line.wide {
+  width: 80%;
+}
+
+@keyframes shimmerSkeleton {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(99, 102, 241, 0.3);
+  border-top-color: #4f46e5;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 /* =================================================================
    Additional Results Page Styles (moved from inline styles)
    ================================================================= */

--- a/self-paced-learning/templates/quiz.html
+++ b/self-paced-learning/templates/quiz.html
@@ -93,6 +93,33 @@
       <button type="submit" class="quiz-submit-button">Submit Quiz</button>
     </form>
 
+    <div id="quiz-feedback-panel" class="quiz-feedback hidden">
+      <div class="quiz-feedback__score">
+        <div class="score-ring">
+          <span id="immediate-score">--%</span>
+        </div>
+        <p class="score-caption">Rule-based score</p>
+      </div>
+      <div class="quiz-feedback__details">
+        <p id="immediate-feedback" class="feedback-text">
+          Immediate feedback will appear here after submission.
+        </p>
+        <ul id="weak-topics-list" class="weak-topics-list"></ul>
+        <div id="analysis-progress" class="analysis-progress">
+          <span class="progress-chip" data-progress-step="score">Score</span>
+          <span class="progress-chip" data-progress-step="weak">Weak Areas</span>
+          <span class="progress-chip" data-progress-step="ai">AI Insights</span>
+        </div>
+        <div id="ai-status" class="ai-status">
+          <span class="spinner" aria-hidden="true"></span>
+          <span id="ai-status-text">Analyzing question patterns...</span>
+        </div>
+        <div id="redirect-notice" class="redirect-notice hidden">
+          Redirecting to detailed results...
+        </div>
+      </div>
+    </div>
+
     <script>
       // Add click handlers for visual feedback
       document.addEventListener("DOMContentLoaded", function () {
@@ -136,33 +163,127 @@
           }
 
           try {
-            // Submit answers to analyze route - Flask session will handle data persistence
             const analyzeResponse = await fetch("/analyze", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ answers: responses }),
             });
 
-            if (analyzeResponse.ok) {
-              // Analysis complete - redirect to results (data is in Flask session)
-              window.location.href = "/results";
-            } else {
-              console.error("Analysis failed:", analyzeResponse.status);
-              alert("Quiz analysis failed. Please try again.");
-              // Re-enable button on error
-              submitButton.disabled = false;
-              submitButton.textContent = originalText;
-              submitButton.classList.remove("disabled");
+            if (!analyzeResponse.ok) {
+              throw new Error(`Analysis failed with status ${analyzeResponse.status}`);
             }
+
+            const analyzePayload = await analyzeResponse.json();
+            if (!analyzePayload.success) {
+              throw new Error(analyzePayload.error || "Analysis request unsuccessful");
+            }
+
+            displayBasicAnalysis(analyzePayload.analysis || {});
+
+            // Kick off async enhancement (fire and forget)
+            try {
+              await fetch("/analyze/enhance", { method: "POST" });
+              setProgressState("ai");
+            } catch (enhanceError) {
+              console.warn("Unable to trigger AI enhancement:", enhanceError);
+              setAiStatus("AI enhancement unavailable. Showing basic results.", true);
+            }
+
+            redirectNotice.classList.remove("hidden");
+            redirectNotice.textContent = "Redirecting to detailed results...";
+
+            setTimeout(() => {
+              window.location.href = "/results";
+            }, 1500);
           } catch (error) {
             console.error("Error during analysis:", error);
-            alert("Error submitting quiz. Please try again.");
-            // Re-enable button on error
+            alert("Quiz analysis failed. Please try again.");
             submitButton.disabled = false;
             submitButton.textContent = originalText;
             submitButton.classList.remove("disabled");
+            feedbackPanel.classList.add("hidden");
           }
         });
+
+      const feedbackPanel = document.getElementById("quiz-feedback-panel");
+      const immediateScore = document.getElementById("immediate-score");
+      const immediateFeedback = document.getElementById("immediate-feedback");
+      const weakTopicsList = document.getElementById("weak-topics-list");
+      const progressChips = document.querySelectorAll(
+        ".progress-chip[data-progress-step]"
+      );
+      const aiStatusText = document.getElementById("ai-status-text");
+      const aiStatusContainer = document.getElementById("ai-status");
+      const redirectNotice = document.getElementById("redirect-notice");
+
+      function displayBasicAnalysis(analysis) {
+        if (!analysis) return;
+        feedbackPanel.classList.remove("hidden");
+        redirectNotice.classList.add("hidden");
+        setAiStatus("Analyzing question patterns...");
+        animateScore(analysis?.score?.percentage ?? 0);
+        immediateFeedback.textContent =
+          analysis.basic_feedback || analysis.feedback || "Great work!";
+        renderWeakTopics(analysis.weak_tags || analysis.weak_topics || []);
+        setProgressState("score");
+        setTimeout(() => setProgressState("weak"), 250);
+      }
+
+      function animateScore(targetScore) {
+        const start = 0;
+        const duration = 600;
+        const startTime = performance.now();
+
+        function update(now) {
+          const elapsed = now - startTime;
+          const progress = Math.min(elapsed / duration, 1);
+          const value = Math.round(start + (targetScore - start) * progress);
+          immediateScore.textContent = `${value}%`;
+          if (progress < 1) {
+            requestAnimationFrame(update);
+          } else {
+            setProgressState("weak");
+            setAiStatus("Enhancing analysis with AI...");
+          }
+        }
+
+        requestAnimationFrame(update);
+      }
+
+      function renderWeakTopics(topics) {
+        weakTopicsList.innerHTML = "";
+        if (!topics || topics.length === 0) {
+          const li = document.createElement("li");
+          li.textContent = "No weak areas detected. Great job!";
+          li.classList.add("all-clear");
+          weakTopicsList.appendChild(li);
+          return;
+        }
+
+        topics.slice(0, 5).forEach((topic) => {
+          const li = document.createElement("li");
+          li.textContent = topic;
+          weakTopicsList.appendChild(li);
+        });
+      }
+
+      function setProgressState(step) {
+        progressChips.forEach((chip) => {
+          const chipStep = chip.dataset.progressStep;
+          if (chipStep === step || chip.classList.contains("completed")) {
+            chip.classList.add("completed");
+          }
+        });
+      }
+
+      function setAiStatus(message, isWarning = false) {
+        aiStatusText.textContent = message;
+        if (isWarning) {
+          aiStatusContainer.classList.add("warning");
+        } else {
+          aiStatusContainer.classList.remove("warning");
+        }
+      }
 
       // Admin override functionality
       function toggleAdminOverride() {
@@ -295,6 +416,165 @@
       .admin-override-notice i {
         color: #ffc107;
         font-size: 1.2em;
+      }
+
+      .quiz-feedback {
+        margin-top: 30px;
+        padding: 20px;
+        border-radius: 16px;
+        background: #f4f6fb;
+        display: flex;
+        gap: 24px;
+        align-items: center;
+        box-shadow: 0 15px 45px rgba(15, 23, 42, 0.08);
+      }
+
+      .quiz-feedback.hidden {
+        display: none;
+      }
+
+      .quiz-feedback__score {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .score-ring {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        background: radial-gradient(circle at top, #4f46e5, #312e81);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 28px;
+        font-weight: 700;
+        box-shadow: inset 0 0 0 6px rgba(255, 255, 255, 0.2);
+      }
+
+      .score-caption {
+        font-size: 14px;
+        color: #4b5563;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+      }
+
+      .quiz-feedback__details {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .feedback-text {
+        font-size: 16px;
+        font-weight: 500;
+        color: #1f2937;
+      }
+
+      .weak-topics-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .weak-topics-list li {
+        background: #eef2ff;
+        color: #312e81;
+        padding: 6px 12px;
+        border-radius: 9999px;
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      .weak-topics-list li.all-clear {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .analysis-progress {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .progress-chip {
+        background: #e5e7eb;
+        color: #374151;
+        padding: 6px 14px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .progress-chip.completed {
+        background: #4f46e5;
+        color: #fff;
+      }
+
+      .progress-chip.completed::after {
+        content: "✓";
+        font-size: 12px;
+      }
+
+      .ai-status {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 14px;
+        color: #4b5563;
+      }
+
+      .ai-status.warning {
+        color: #b91c1c;
+      }
+
+      .spinner {
+        width: 16px;
+        height: 16px;
+        border: 2px solid rgba(99, 102, 241, 0.3);
+        border-top-color: #4f46e5;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+
+      .redirect-notice {
+        font-size: 13px;
+        color: #2563eb;
+        font-weight: 600;
+      }
+
+      .redirect-notice.hidden {
+        display: none;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (max-width: 768px) {
+        .quiz-feedback {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .score-ring {
+          width: 90px;
+          height: 90px;
+          font-size: 22px;
+        }
       }
 
       /* Disabled button styles */

--- a/self-paced-learning/templates/results.html
+++ b/self-paced-learning/templates/results.html
@@ -61,6 +61,26 @@
             </div>
           </div>
 
+          <div
+            id="analysis-progress-tracker"
+            class="analysis-progress-tracker hidden"
+          >
+            <span class="progress-pill" data-progress="score">Score</span>
+            <span class="progress-pill" data-progress="weak">Weak Areas</span>
+            <span class="progress-pill" data-progress="ai">AI Insights</span>
+          </div>
+
+          <div id="ai-enhancement-banner" class="ai-enhancement-banner hidden">
+            <span class="spinner" aria-hidden="true"></span>
+            <span id="ai-enhancement-text">Enhancing analysis with AI...</span>
+          </div>
+
+          <div id="ai-feedback-skeleton" class="ai-feedback-skeleton hidden">
+            <div class="skeleton-line wide"></div>
+            <div class="skeleton-line"></div>
+            <div class="skeleton-line"></div>
+          </div>
+
           {% if quiz_generation_error %}
           <div id="quiz-generation-error-message" class="status status-error">
             <strong>Error:</strong> {{ quiz_generation_error }}
@@ -91,6 +111,9 @@
       const CURRENT_SUBJECT = {{ CURRENT_SUBJECT | tojson | safe }};
       const CURRENT_SUBTOPIC = {{ CURRENT_SUBTOPIC | tojson | safe }};
       const ANALYSIS_RESULTS = {{ ANALYSIS_RESULTS | tojson | safe }};
+      const ENHANCEMENT_STATUS = {{ ENHANCEMENT_STATUS | tojson | safe }};
+      const HAS_ENHANCED = {{ HAS_ENHANCED | tojson | safe }};
+      const AI_AVAILABLE = {{ AI_AVAILABLE | tojson | safe }};
     </script>
 
     <script>
@@ -116,6 +139,22 @@
               const adminMarkCompleteButton = document.getElementById(
                 "adminMarkCompleteButton"
               );
+              const progressTracker = document.getElementById(
+                "analysis-progress-tracker"
+              );
+              const progressPills = document.querySelectorAll(
+                ".progress-pill"
+              );
+              const aiBanner = document.getElementById("ai-enhancement-banner");
+              const aiBannerText = document.getElementById(
+                "ai-enhancement-text"
+              );
+              const aiSkeleton = document.getElementById("ai-feedback-skeleton");
+
+              let enhancementPollingActive = false;
+              let initialRenderCompleted = false;
+              let currentAnalysis = ANALYSIS_RESULTS || {};
+              const aiAvailable = Boolean(AI_AVAILABLE);
 
               // --- State Tracking ---
               let completionState = {};
@@ -143,7 +182,8 @@
               statusDiv.textContent = "Analysis complete!";
               statusDiv.className = "status status-success";
 
-              await processAnalysisResults(ANALYSIS_RESULTS);
+              await processAnalysisResults(currentAnalysis);
+              configureEnhancementUI(ENHANCEMENT_STATUS);
 
               // --- Helper Functions ---
               function resolveLesson(keyOrId) {
@@ -221,7 +261,13 @@
               });
 
               // --- Analysis Results Processing Function ---
-              async function processAnalysisResults(analysisData) {
+              async function processAnalysisResults(
+                analysisData,
+                options = {}
+              ) {
+                if (!analysisData) return;
+
+                const { isEnhanced = false } = options;
                 console.log("Processing analysis results:", analysisData);
 
                 const weakTopics =
@@ -229,16 +275,23 @@
                     ? analysisData.weak_topics
                     : analysisData.weak_tags) || [];
 
-                // Calculate and display score
+                completionState = {};
+
                 if (analysisData.score) {
-                  displayScore(analysisData.score);
+                  displayScore(analysisData.score, {
+                    animate: !initialRenderCompleted,
+                  });
                 }
 
                 statusDiv.classList.add("hidden");
 
                 if (weakTopics.length > 0) {
                   welcomeMessageContainer.classList.remove("hidden");
-                  feedbackContentDiv.innerHTML = analysisData.feedback;
+                  masteryMessageContainer.classList.add("hidden");
+                  feedbackContentDiv.innerHTML =
+                    analysisData.feedback ||
+                    analysisData.ai_analysis ||
+                    "Focused practice recommendations will appear here.";
 
                   buildCompletionState(weakTopics);
                   displayWeakTopics(weakTopics);
@@ -247,12 +300,22 @@
                   backToTopicsButton.classList.remove("hidden");
                   checkCompletionAndToggleButton();
                 } else {
+                  topicsNavList.innerHTML = "";
+                  welcomeMessageContainer.classList.add("hidden");
                   masteryMessageContainer.classList.remove("hidden");
                   backToTopicsButton.classList.remove("hidden");
-                  // Show continue button for perfect scores too
                   continueButton.classList.remove("hidden");
-                  continueButton.disabled = false; // Enable button when no weak topics
+                  continueButton.disabled = false;
+                  updateProgress("weak");
                 }
+
+                if (isEnhanced) {
+                  updateProgress("ai");
+                  setAiBanner("AI insights ready!", "success");
+                  aiSkeleton.classList.add("hidden");
+                }
+
+                initialRenderCompleted = true;
               }
 
               // --- Simplified Topic Display ---
@@ -274,6 +337,8 @@
                  `;
                   topicsNavList.appendChild(groupLi);
                 });
+
+                updateProgress("weak");
               }
 
               // --- Helper Functions ---
@@ -284,15 +349,27 @@
               }
 
               // --- Score Display Function ---
-              function displayScore(scoreData) {
+              function displayScore(scoreData, options = {}) {
+                if (!scoreData) return;
                 const { correct, total, percentage } = scoreData;
+                const { animate = true } = options;
 
-                // Update score display
-                scoreDisplay.textContent = `${percentage}%`;
                 correctCount.textContent = correct;
                 totalCount.textContent = total;
 
-                // Apply score-based styling
+                applyScoreStyling(percentage);
+
+                if (animate) {
+                  animateScoreDisplay(percentage);
+                } else {
+                  scoreDisplay.textContent = `${Math.round(percentage)}%`;
+                }
+
+                scoreContainer.classList.remove("hidden");
+                updateProgress("score");
+              }
+
+              function applyScoreStyling(percentage) {
                 scoreContainer.classList.remove(
                   "score-excellent",
                   "score-good",
@@ -305,9 +382,158 @@
                 } else {
                   scoreContainer.classList.add("score-needs-improvement");
                 }
+              }
 
-                // Show the score container
-                scoreContainer.classList.remove("hidden");
+              function animateScoreDisplay(targetPercentage) {
+                const startValue = 0;
+                const duration = 800;
+                const startTime = performance.now();
+
+                function update(now) {
+                  const elapsed = now - startTime;
+                  const progress = Math.min(elapsed / duration, 1);
+                  const value = Math.round(
+                    startValue + (targetPercentage - startValue) * progress
+                  );
+                  scoreDisplay.textContent = `${value}%`;
+                  if (progress < 1) {
+                    requestAnimationFrame(update);
+                  }
+                }
+
+                requestAnimationFrame(update);
+              }
+
+              function updateProgress(step, variant = "completed") {
+                if (!progressTracker) return;
+                progressTracker.classList.remove("hidden");
+                progressPills.forEach((pill) => {
+                  if (pill.dataset.progress === step) {
+                    if (variant === "error") {
+                      pill.classList.add("error");
+                    } else {
+                      pill.classList.add("completed");
+                      pill.classList.remove("error");
+                    }
+                  }
+                });
+              }
+
+              function setAiBanner(message, variant = "loading") {
+                if (!aiBanner || !aiBannerText) return;
+                aiBannerText.textContent = message;
+                aiBanner.classList.remove("hidden", "success", "error");
+                const spinnerEl = aiBanner.querySelector(".spinner");
+                if (variant === "loading") {
+                  aiBanner.classList.remove("success", "error");
+                  if (spinnerEl) spinnerEl.style.display = "inline-block";
+                } else if (variant === "success") {
+                  aiBanner.classList.add("success");
+                  if (spinnerEl) spinnerEl.style.display = "none";
+                } else if (variant === "error") {
+                  aiBanner.classList.add("error");
+                  if (spinnerEl) spinnerEl.style.display = "none";
+                }
+              }
+
+              function configureEnhancementUI(status) {
+                if (!aiBanner || !progressTracker) return;
+                if (!aiAvailable) {
+                  progressTracker.classList.remove("hidden");
+                  aiBanner.classList.add("hidden");
+                  aiSkeleton.classList.add("hidden");
+                  return;
+                }
+
+                let normalizedStatus = (status || "").toString().toLowerCase();
+                if (
+                  (!normalizedStatus || normalizedStatus === "none") &&
+                  currentAnalysis &&
+                  currentAnalysis.analysis_stage === "enhanced"
+                ) {
+                  normalizedStatus = "completed";
+                }
+
+                if (normalizedStatus === "completed" || HAS_ENHANCED) {
+                  setAiBanner("AI insights ready!", "success");
+                  updateProgress("ai");
+                  aiSkeleton.classList.add("hidden");
+                } else if (normalizedStatus === "failed") {
+                  handleEnhancementFailure(
+                    "AI insights unavailable. Showing basic guidance."
+                  );
+                } else {
+                  aiBanner.classList.remove("hidden");
+                  aiSkeleton.classList.remove("hidden");
+                  setAiBanner("Enhancing analysis with AI...", "loading");
+                  if (!enhancementPollingActive) {
+                    enhancementPollingActive = true;
+                    startEnhancementPolling(normalizedStatus);
+                  }
+                }
+              }
+
+              function handleEnhancementFailure(message) {
+                setAiBanner(message || "AI enhancement unavailable.", "error");
+                updateProgress("ai", "error");
+                aiSkeleton.classList.add("hidden");
+              }
+
+              function startEnhancementPolling(initialStatus) {
+                if (!aiAvailable) return;
+                const allowedStatuses = [
+                  "pending",
+                  "in_progress",
+                  "basic",
+                  "basic_ready",
+                ];
+                if (!allowedStatuses.includes(initialStatus)) {
+                  return;
+                }
+
+                let attempts = 0;
+                const maxAttempts = 10;
+                const intervalMs = 2500;
+
+                const poll = async () => {
+                  attempts += 1;
+                  try {
+                    const response = await fetch("/analyze/enhance");
+                    if (!response.ok) {
+                      throw new Error(`Status ${response.status}`);
+                    }
+                    const payload = await response.json();
+                    if (payload.status === "completed" && payload.analysis) {
+                      currentAnalysis = payload.analysis;
+                      await processAnalysisResults(currentAnalysis, {
+                        isEnhanced: true,
+                      });
+                      configureEnhancementUI("completed");
+                      return;
+                    }
+                    if (payload.status === "failed") {
+                      handleEnhancementFailure(payload.error);
+                      return;
+                    }
+                    if (payload.status === "error") {
+                      handleEnhancementFailure(payload.error);
+                      return;
+                    }
+                  } catch (error) {
+                    console.error("Error polling enhancement:", error);
+                  }
+
+                  if (attempts >= maxAttempts) {
+                    handleEnhancementFailure(
+                      "AI enhancement timed out. Showing basic guidance."
+                    );
+                    return;
+                  }
+
+                  setTimeout(poll, intervalMs);
+                };
+
+                setTimeout(poll, intervalMs);
               }
 
               // --- Score Display Function (duplicate click handler removed) ---


### PR DESCRIPTION
## Summary
- ensure the AI quiz analysis fallback keeps weak tags and feedback synchronized with cached results
- propagate missed tag metadata and ai_analysis text so the UI receives consistent feedback when enhancements fail

## Testing
- pytest *(fails: DataService fixtures require a data_root_path and service integration route returns 403)*
- flake8 *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e079020708832f882e07ad213206b8