### PR TITLE
Relax wrap spacing in admin overview controls

### DIFF
--- a/self-paced-learning/templates/admin/all_lessons.html
+++ b/self-paced-learning/templates/admin/all_lessons.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>All Lessons Overview - Admin Panel</title>
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+  </head>
+  <body class="admin-body">
+    <div class="admin-layout">
+      <nav class="admin-sidebar">
+        <div class="admin-logo">
+          <h2><i class="fas fa-cog"></i> Admin Panel</h2>
+          <a href="/" class="back-to-site">← Back to Site</a>
+        </div>
+        <ul class="admin-nav">
+          <li>
+            <a href="/admin"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
+          </li>
+          <li>
+            <a href="/admin/subjects"
+              ><i class="fas fa-book-open"></i> Subjects</a
+            >
+          </li>
+          <li>
+            <a href="/admin/subtopics/select-subject"
+              ><i class="fas fa-sitemap"></i> Subtopics</a
+            >
+          </li>
+          <li>
+            <a href="/admin/lessons/select-subject"
+              ><i class="fas fa-chalkboard-teacher"></i> Lessons</a
+            >
+          </li>
+          <li>
+            <a href="/admin/questions/select-subject"
+              ><i class="fas fa-question-circle"></i> Questions</a
+            >
+          </li>
+          <li>
+            <a href="/admin/export"
+              ><i class="fas fa-download"></i> Export/Import</a
+            >
+          </li>
+          <li>
+            <span class="nav-heading">Overview</span>
+          </li>
+          <li>
+            <a href="/admin/overview/subtopics"
+              ><i class="fas fa-layer-group"></i> All Subtopics</a
+            >
+          </li>
+          <li>
+            <a href="/admin/overview/lessons" class="active"
+              ><i class="fas fa-book-reader"></i> All Lessons</a
+            >
+          </li>
+          <li>
+            <a href="/admin/overview/questions"
+              ><i class="fas fa-list-ol"></i> All Questions</a
+            >
+          </li>
+        </ul>
+      </nav>
+
+      <main class="admin-content">
+        <header class="admin-header">
+          <div class="header-actions">
+            <div>
+              <h1><i class="fas fa-book-reader"></i> All Lessons Overview</h1>
+              <p>Review every lesson by subject and subtopic at a glance.</p>
+            </div>
+            <div class="admin-actions">
+              <a
+                href="{{ url_for('admin.admin_select_subject_for_lessons') }}"
+                class="btn-primary"
+              >
+                <i class="fas fa-edit"></i>
+                Manage Lessons
+              </a>
+              <a
+                href="{{ url_for('admin.admin_create_lesson') }}"
+                class="btn-secondary"
+              >
+                <i class="fas fa-plus"></i>
+                Create Lesson
+              </a>
+            </div>
+          </div>
+        </header>
+
+        {% if error %}
+        <div class="empty-state">
+          <i class="fas fa-exclamation-triangle"></i>
+          <h3>Unable to load lessons</h3>
+          <p>{{ error }}</p>
+        </div>
+        {% else %}
+        <section class="stats-overview">
+          <div class="stat-card">
+            <div class="stat-icon">
+              <i class="fas fa-book-reader"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.total_lessons | default(0) }}</h3>
+              <p>Total Lessons</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #ed8936, #dd6b20);">
+              <i class="fas fa-school"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.subjects_with_lessons | default(0) }}</h3>
+              <p>Subjects With Lessons</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #48bb78, #2f855a);">
+              <i class="fas fa-layer-group"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.subtopics_with_lessons | default(0) }}</h3>
+              <p>Subtopics With Lessons</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #f56565, #c53030);">
+              <i class="fas fa-exclamation-circle"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.subtopics_without_lessons | default(0) }}</h3>
+              <p>Need Lessons</p>
+            </div>
+          </div>
+        </section>
+
+        {% if subjects %}
+        {% for subject in subjects %}
+        <section class="subject-section">
+          <div class="subject-header">
+            <div class="subject-title">
+              <div
+                class="subject-icon"
+                style="background: {{ subject.color or '#4a5568' }};"
+              >
+                <i class="{{ subject.icon or 'fas fa-book' }}"></i>
+              </div>
+              <div>
+                <h2>{{ subject.name }}</h2>
+                <p>{{ subject.description }}</p>
+              </div>
+            </div>
+            <div class="admin-actions">
+              <span class="badge success">
+                <i class="fas fa-book-reader"></i>
+                {{ subject.lesson_count }} lesson{{ 's' if subject.lesson_count != 1 else '' }}
+              </span>
+              <span class="badge warning">
+                <i class="fas fa-layer-group"></i>
+                {{ subject.subtopics | length }} subtopic{{ 's' if subject.subtopics | length != 1 else '' }}
+              </span>
+              <a
+                href="{{ url_for('admin.admin_select_subtopic_for_lessons', subject=subject.id) }}"
+                class="btn-secondary"
+              >
+                <i class="fas fa-sitemap"></i>
+                Manage {{ subject.name }}
+              </a>
+            </div>
+          </div>
+
+          {% if subject.subtopics %}
+          {% for subtopic in subject.subtopics %}
+          <div class="subtopic-section">
+            <div class="subtopic-header">
+              <div>
+                <h3>{{ subtopic.name }}</h3>
+                {% if subtopic.description %}
+                <p>{{ subtopic.description }}</p>
+                {% endif %}
+              </div>
+              <div class="subtopic-meta">
+                <span class="badge {{ 'success' if subtopic.lesson_count > 0 else 'danger' }}">
+                  <i class="fas fa-book-reader"></i>
+                  {{ subtopic.lesson_count }} lesson{{ 's' if subtopic.lesson_count != 1 else '' }}
+                </span>
+                {% if subtopic.estimated_time %}
+                <span class="status-pill warn">
+                  <i class="fas fa-clock"></i>
+                  {{ subtopic.estimated_time }}
+                </span>
+                {% endif %}
+                {% if subtopic.prerequisites %}
+                <span class="status-pill warn">
+                  <i class="fas fa-link"></i>
+                  {{ subtopic.prerequisites | length }} prerequisite{{ 's' if subtopic.prerequisites | length != 1 else '' }}
+                </span>
+                {% endif %}
+              </div>
+            </div>
+
+            {% if subtopic.lessons %}
+            <div class="table-container nested-table">
+              <table class="admin-table">
+                <thead>
+                  <tr>
+                    <th>Lesson</th>
+                    <th>Type</th>
+                    <th>Content Blocks</th>
+                    <th>Tags</th>
+                    <th>Updated</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for lesson in subtopic.lessons %}
+                  <tr>
+                    <td>
+                      <strong>{{ lesson.title }}</strong>
+                      <div class="status-pill">
+                        <i class="fas fa-sort-numeric-up"></i>
+                        Order {{ lesson.order or 0 }}
+                      </div>
+                    </td>
+                    <td>
+                      <span class="badge success">
+                        <i class="fas fa-tag"></i>
+                        {{ lesson.type | title }}
+                      </span>
+                    </td>
+                    <td>
+                      <span class="badge warning">
+                        <i class="fas fa-file-alt"></i>
+                        {{ lesson.content_length }}
+                      </span>
+                    </td>
+                    <td class="tags-column">
+                      {% if lesson.tags %}
+                      {% for tag in lesson.tags %}
+                      <span class="status-pill warn">
+                        <i class="fas fa-hashtag"></i>
+                        {{ tag }}
+                      </span>
+                      {% endfor %}
+                      {% else %}
+                      <span class="status-pill bad">
+                        <i class="fas fa-minus-circle"></i>
+                        No tags
+                      </span>
+                      {% endif %}
+                    </td>
+                    <td>
+                      {% if lesson.updated_date %}
+                      <span class="status-pill">
+                        <i class="fas fa-calendar"></i>
+                        {{ lesson.updated_date }}
+                      </span>
+                      {% else %}
+                      <span class="status-pill warn">
+                        <i class="fas fa-calendar"></i>
+                        Not set
+                      </span>
+                      {% endif %}
+                    </td>
+                    <td>
+                      <a
+                        href="{{ url_for('admin.admin_edit_lesson', subject=subject.id, subtopic=subtopic.id, lesson_id=lesson.id) }}"
+                        class="btn-small"
+                      >
+                        <i class="fas fa-edit"></i>
+                        Edit
+                      </a>
+                      <a
+                        href="{{ url_for('admin.admin_lessons', subject=subject.id, subtopic=subtopic.id) }}"
+                        class="btn-small"
+                      >
+                        <i class="fas fa-arrows-alt"></i>
+                        Reorder
+                      </a>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            {% else %}
+            <div class="empty-state compact">
+              <i class="fas fa-book-reader"></i>
+              <h4>No lessons yet</h4>
+              <p>Create your first lesson for {{ subtopic.name }}.</p>
+              <a
+                href="{{ url_for('admin.admin_lessons', subject=subject.id, subtopic=subtopic.id) }}"
+                class="btn-primary"
+              >
+                <i class="fas fa-plus"></i>
+                Create Lesson
+              </a>
+            </div>
+            {% endif %}
+          </div>
+          {% endfor %}
+          {% else %}
+          <div class="empty-state compact">
+            <i class="fas fa-layer-group"></i>
+            <h4>No subtopics yet</h4>
+            <p>Set up subtopics to start organizing lessons for {{ subject.name }}.</p>
+            <a
+              href="{{ url_for('admin.admin_select_subject_for_subtopics') }}"
+              class="btn-primary"
+            >
+              <i class="fas fa-plus"></i>
+              Create Subtopic
+            </a>
+          </div>
+          {% endif %}
+        </section>
+        {% endfor %}
+        {% else %}
+        <div class="empty-state">
+          <i class="fas fa-book-reader"></i>
+          <h3>No lessons found</h3>
+          <p>Start by creating subjects and lessons to populate this overview.</p>
+          <a href="{{ url_for('admin.admin_create_lesson') }}" class="btn-primary">
+            <i class="fas fa-plus"></i>
+            Create Lesson
+          </a>
+        </div>
+        {% endif %}
+        {% endif %}
+      </main>
+    </div>
+
+    {% include 'admin/partials/overview_styles.html' %}
+  </body>
+</html>

--- a/self-paced-learning/templates/admin/all_questions.html
+++ b/self-paced-learning/templates/admin/all_questions.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>All Questions Overview - Admin Panel</title>
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+  </head>
+  <body class="admin-body">
+    <div class="admin-layout">
+      <nav class="admin-sidebar">
+        <div class="admin-logo">
+          <h2><i class="fas fa-cog"></i> Admin Panel</h2>
+          <a href="/" class="back-to-site">← Back to Site</a>
+        </div>
+        <ul class="admin-nav">
+          <li>
+            <a href="/admin"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
+          </li>
+          <li>
+            <a href="/admin/subjects"
+              ><i class="fas fa-book-open"></i> Subjects</a
+            >
+          </li>
+          <li>
+            <a href="/admin/subtopics/select-subject"
+              ><i class="fas fa-sitemap"></i> Subtopics</a
+            >
+          </li>
+          <li>
+            <a href="/admin/lessons/select-subject"
+              ><i class="fas fa-chalkboard-teacher"></i> Lessons</a
+            >
+          </li>
+          <li>
+            <a href="/admin/questions/select-subject"
+              ><i class="fas fa-question-circle"></i> Questions</a
+            >
+          </li>
+          <li>
+            <a href="/admin/export"
+              ><i class="fas fa-download"></i> Export/Import</a
+            >
+          </li>
+          <li>
+            <span class="nav-heading">Overview</span>
+          </li>
+          <li>
+            <a href="/admin/overview/subtopics"
+              ><i class="fas fa-layer-group"></i> All Subtopics</a
+            >
+          </li>
+          <li>
+            <a href="/admin/overview/lessons"
+              ><i class="fas fa-book-reader"></i> All Lessons</a
+            >
+          </li>
+          <li>
+            <a href="/admin/overview/questions" class="active"
+              ><i class="fas fa-list-ol"></i> All Questions</a
+            >
+          </li>
+        </ul>
+      </nav>
+
+      <main class="admin-content">
+        <header class="admin-header">
+          <div class="header-actions">
+            <div>
+              <h1><i class="fas fa-list-ol"></i> All Questions Overview</h1>
+              <p>Track question coverage for every subtopic.</p>
+            </div>
+            <div class="admin-actions">
+              <a
+                href="{{ url_for('admin.admin_select_subject_for_questions') }}"
+                class="btn-primary"
+              >
+                <i class="fas fa-edit"></i>
+                Manage Questions
+              </a>
+              <a
+                href="{{ url_for('admin.admin_select_subject_for_subtopics') }}"
+                class="btn-secondary"
+              >
+                <i class="fas fa-layer-group"></i>
+                Review Subtopics
+              </a>
+            </div>
+          </div>
+        </header>
+
+        {% if error %}
+        <div class="empty-state">
+          <i class="fas fa-exclamation-triangle"></i>
+          <h3>Unable to load questions</h3>
+          <p>{{ error }}</p>
+        </div>
+        {% else %}
+        <section class="stats-overview">
+          <div class="stat-card">
+            <div class="stat-icon">
+              <i class="fas fa-layer-group"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.total_subtopics | default(0) }}</h3>
+              <p>Subtopics</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #4299e1, #3182ce);">
+              <i class="fas fa-clipboard-check"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.total_initial_questions | default(0) }}</h3>
+              <p>Initial Quiz Questions</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #ed8936, #dd6b20);">
+              <i class="fas fa-database"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.total_pool_questions | default(0) }}</h3>
+              <p>Pool Questions</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #f56565, #c53030);">
+              <i class="fas fa-exclamation-circle"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.subtopics_without_questions | default(0) }}</h3>
+              <p>Need Questions</p>
+            </div>
+          </div>
+        </section>
+
+        {% if subjects %}
+        {% for subject in subjects %}
+        <section class="subject-section">
+          <div class="subject-header">
+            <div class="subject-title">
+              <div
+                class="subject-icon"
+                style="background: {{ subject.color or '#4a5568' }};"
+              >
+                <i class="{{ subject.icon or 'fas fa-book' }}"></i>
+              </div>
+              <div>
+                <h2>{{ subject.name }}</h2>
+                <p>{{ subject.description }}</p>
+              </div>
+            </div>
+            <div class="admin-actions">
+              <span class="badge success">
+                <i class="fas fa-clipboard-check"></i>
+                {{ subject.initial_count }} initial
+              </span>
+              <span class="badge warning">
+                <i class="fas fa-database"></i>
+                {{ subject.pool_count }} pool
+              </span>
+            </div>
+          </div>
+
+          {% if subject.subtopics %}
+          <div class="table-container">
+            <table class="admin-table">
+              <thead>
+                <tr>
+                  <th>Subtopic</th>
+                  <th>Lessons</th>
+                  <th>Initial Questions</th>
+                  <th>Pool Questions</th>
+                  <th>Total</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for subtopic in subject.subtopics %}
+                <tr>
+                  <td>
+                    <strong>{{ subtopic.name }}</strong>
+                    {% if subtopic.estimated_time %}
+                    <div class="status-pill">
+                      <i class="fas fa-clock"></i>
+                      {{ subtopic.estimated_time }}
+                    </div>
+                    {% endif %}
+                    {% if subtopic.prerequisites %}
+                    <div class="status-pill warn">
+                      <i class="fas fa-link"></i>
+                      {{ subtopic.prerequisites|length }} prerequisite{{ 's' if subtopic.prerequisites|length != 1 else '' }}
+                    </div>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if subtopic.lesson_count > 0 %}
+                    <span class="badge success">
+                      <i class="fas fa-chalkboard-teacher"></i>
+                      {{ subtopic.lesson_count }}
+                    </span>
+                    {% else %}
+                    <span class="badge danger">
+                      <i class="fas fa-exclamation-triangle"></i>
+                      None
+                    </span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <span class="badge {{ 'success' if subtopic.quiz_questions_count > 0 else 'danger' }}">
+                      <i class="fas fa-clipboard-check"></i>
+                      {{ subtopic.quiz_questions_count }}
+                    </span>
+                  </td>
+                  <td>
+                    <span class="badge {{ 'warning' if subtopic.pool_questions_count > 0 else 'danger' }}">
+                      <i class="fas fa-database"></i>
+                      {{ subtopic.pool_questions_count }}
+                    </span>
+                  </td>
+                  <td>
+                    <span class="badge success">
+                      <i class="fas fa-list-ol"></i>
+                      {{ subtopic.total_questions }}
+                    </span>
+                  </td>
+                  <td>
+                    {% if subtopic.total_questions > 0 %}
+                    <span class="status-pill good">
+                      <i class="fas fa-check"></i>
+                      Ready
+                    </span>
+                    {% else %}
+                    <span class="status-pill bad">
+                      <i class="fas fa-times"></i>
+                      Needs Questions
+                    </span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <a
+                      href="{{ url_for('admin.admin_questions', subject=subject.id, subtopic=subtopic.id) }}"
+                      class="btn-small"
+                    >
+                      <i class="fas fa-edit"></i>
+                      Edit
+                    </a>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <div class="empty-state">
+            <i class="fas fa-layer-group"></i>
+            <h3>No subtopics found</h3>
+            <p>Create subtopics for {{ subject.name }} to begin adding questions.</p>
+            <a
+              href="{{ url_for('admin.admin_select_subject_for_subtopics') }}"
+              class="btn-primary"
+            >
+              <i class="fas fa-plus"></i>
+              Create Subtopic
+            </a>
+          </div>
+          {% endif %}
+        </section>
+        {% endfor %}
+        {% else %}
+        <div class="empty-state">
+          <i class="fas fa-question"></i>
+          <h3>No subjects available</h3>
+          <p>Start by creating a subject to manage questions.</p>
+          <a href="/admin/subjects/create" class="btn-primary">
+            <i class="fas fa-plus"></i>
+            Create Subject
+          </a>
+        </div>
+        {% endif %}
+        {% endif %}
+      </main>
+    </div>
+
+    {% include 'admin/partials/overview_styles.html' %}
+  </body>
+</html>

--- a/self-paced-learning/templates/admin/all_subtopics.html
+++ b/self-paced-learning/templates/admin/all_subtopics.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>All Subtopics Overview - Admin Panel</title>
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+    />
+  </head>
+  <body class="admin-body">
+    <div class="admin-layout">
+      <nav class="admin-sidebar">
+        <div class="admin-logo">
+          <h2><i class="fas fa-cog"></i> Admin Panel</h2>
+          <a href="/" class="back-to-site">← Back to Site</a>
+        </div>
+        <ul class="admin-nav">
+          <li>
+            <a href="/admin"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
+          </li>
+          <li>
+            <a href="/admin/subjects"
+              ><i class="fas fa-book-open"></i> Subjects</a
+            >
+          </li>
+          <li>
+            <a href="/admin/subtopics/select-subject"
+              ><i class="fas fa-sitemap"></i> Subtopics</a
+            >
+          </li>
+          <li>
+            <a href="/admin/lessons/select-subject"
+              ><i class="fas fa-chalkboard-teacher"></i> Lessons</a
+            >
+          </li>
+          <li>
+            <a href="/admin/questions/select-subject"
+              ><i class="fas fa-question-circle"></i> Questions</a
+            >
+          </li>
+          <li>
+            <a href="/admin/export"
+              ><i class="fas fa-download"></i> Export/Import</a
+            >
+          </li>
+          <li>
+            <span class="nav-heading">Overview</span>
+          </li>
+          <li>
+            <a href="/admin/overview/subtopics" class="active"
+              ><i class="fas fa-layer-group"></i> All Subtopics</a
+            >
+          </li>
+          <li>
+            <a href="/admin/overview/lessons"
+              ><i class="fas fa-book-reader"></i> All Lessons</a
+            >
+          </li>
+          <li>
+            <a href="/admin/overview/questions"
+              ><i class="fas fa-list-ol"></i> All Questions</a
+            >
+          </li>
+        </ul>
+      </nav>
+
+      <main class="admin-content">
+        <header class="admin-header">
+          <div class="header-actions">
+            <div>
+              <h1><i class="fas fa-layer-group"></i> All Subtopics Overview</h1>
+              <p>Audit lesson and question coverage across every subtopic.</p>
+            </div>
+            <div class="admin-actions">
+              <a
+                href="{{ url_for('admin.admin_select_subject_for_subtopics') }}"
+                class="btn-primary"
+              >
+                <i class="fas fa-edit"></i>
+                Manage Subtopics
+              </a>
+              <a
+                href="{{ url_for('admin.admin_select_subject_for_lessons') }}"
+                class="btn-secondary"
+              >
+                <i class="fas fa-chalkboard"></i>
+                Manage Lessons
+              </a>
+            </div>
+          </div>
+        </header>
+
+        {% if error %}
+        <div class="empty-state">
+          <i class="fas fa-exclamation-triangle"></i>
+          <h3>Unable to load subtopics</h3>
+          <p>{{ error }}</p>
+        </div>
+        {% else %}
+        <section class="stats-overview">
+          <div class="stat-card">
+            <div class="stat-icon">
+              <i class="fas fa-layer-group"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.total_subtopics | default(0) }}</h3>
+              <p>Total Subtopics</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #48bb78, #2f855a);">
+              <i class="fas fa-chalkboard-teacher"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ (stats.total_subtopics | default(0)) - (stats.subtopics_without_lessons | default(0)) }}</h3>
+              <p>With Lessons</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #4299e1, #3182ce);">
+              <i class="fas fa-clipboard-check"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.total_questions | default(0) }}</h3>
+              <p>Total Questions</p>
+            </div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background: linear-gradient(135deg, #f56565, #c53030);">
+              <i class="fas fa-question"></i>
+            </div>
+            <div class="stat-info">
+              <h3>{{ stats.subtopics_without_questions | default(0) }}</h3>
+              <p>Missing Questions</p>
+            </div>
+          </div>
+        </section>
+
+        {% if subjects %}
+        <section class="summary-grid">
+          {% for subject in subjects %}
+          <div class="summary-card">
+            <h3>{{ subject.name }}</h3>
+            <p>
+              {{ subject.subtopics|length }} subtopic{{ 's' if subject.subtopics|length != 1 else '' }} ·
+              {{ subject.lesson_ready_count }} ready for lessons ·
+              {{ subject.question_ready_count }} ready for quizzes
+            </p>
+            <a
+              href="{{ url_for('admin.admin_subtopics', subject=subject.id) }}"
+              class="btn-link"
+            >
+              Manage {{ subject.name }} subtopics
+              <i class="fas fa-arrow-right"></i>
+            </a>
+          </div>
+          {% endfor %}
+        </section>
+
+        {% for subject in subjects %}
+        <section class="subject-section">
+          <div class="subject-header">
+            <div class="subject-title">
+              <div
+                class="subject-icon"
+                style="background: {{ subject.color or '#4a5568' }};"
+              >
+                <i class="{{ subject.icon or 'fas fa-book' }}"></i>
+              </div>
+              <div>
+                <h2>{{ subject.name }}</h2>
+                <p>{{ subject.description }}</p>
+              </div>
+            </div>
+            <div class="admin-actions">
+              <span class="badge success">
+                <i class="fas fa-check"></i>
+                {{ subject.lesson_ready_count }} with lessons
+              </span>
+              <span class="badge warning">
+                <i class="fas fa-question"></i>
+                {{ subject.question_ready_count }} with questions
+              </span>
+            </div>
+          </div>
+
+          {% if subject.subtopics %}
+          <div class="table-container">
+            <table class="admin-table">
+              <thead>
+                <tr>
+                  <th>Subtopic</th>
+                  <th>Lessons</th>
+                  <th>Questions</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for subtopic in subject.subtopics %}
+                <tr>
+                  <td>
+                    <strong>{{ subtopic.name }}</strong>
+                    {% if subtopic.estimated_time %}
+                    <div class="status-pill">
+                      <i class="fas fa-clock"></i>
+                      {{ subtopic.estimated_time }}
+                    </div>
+                    {% endif %}
+                    {% if subtopic.prerequisites %}
+                    <div class="status-pill warn">
+                      <i class="fas fa-link"></i>
+                      {{ subtopic.prerequisites|length }} prerequisite{{ 's' if subtopic.prerequisites|length != 1 else '' }}
+                    </div>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if subtopic.has_lessons %}
+                    <span class="badge success">
+                      <i class="fas fa-chalkboard-teacher"></i>
+                      {{ subtopic.lesson_count }}
+                    </span>
+                    {% else %}
+                    <span class="badge danger">
+                      <i class="fas fa-exclamation-triangle"></i>
+                      None
+                    </span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if subtopic.has_questions %}
+                    <span class="badge success">
+                      <i class="fas fa-list-ol"></i>
+                      {{ subtopic.total_questions }}
+                    </span>
+                    {% else %}
+                    <span class="badge danger">
+                      <i class="fas fa-exclamation-circle"></i>
+                      None
+                    </span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    {% if subtopic.has_lessons and subtopic.has_questions %}
+                    <span class="status-pill good">
+                      <i class="fas fa-check"></i>
+                      Ready
+                    </span>
+                    {% elif subtopic.has_lessons %}
+                    <span class="status-pill warn">
+                      <i class="fas fa-question"></i>
+                      Add Questions
+                    </span>
+                    {% elif subtopic.has_questions %}
+                    <span class="status-pill warn">
+                      <i class="fas fa-chalkboard"></i>
+                      Add Lessons
+                    </span>
+                    {% else %}
+                    <span class="status-pill bad">
+                      <i class="fas fa-flag"></i>
+                      Needs Content
+                    </span>
+                    {% endif %}
+                  </td>
+                  <td>
+                    <div class="admin-actions">
+                      <a
+                        href="{{ url_for('admin.admin_edit_subtopic', subject=subject.id, subtopic=subtopic.id) }}"
+                        class="btn-small"
+                      >
+                        <i class="fas fa-pen"></i>
+                        Edit
+                      </a>
+                      <a
+                        href="{{ url_for('admin.admin_lessons', subject=subject.id, subtopic=subtopic.id) }}"
+                        class="btn-small"
+                      >
+                        <i class="fas fa-book-reader"></i>
+                        Lessons
+                      </a>
+                      <a
+                        href="{{ url_for('admin.admin_questions', subject=subject.id, subtopic=subtopic.id) }}"
+                        class="btn-small"
+                      >
+                        <i class="fas fa-question-circle"></i>
+                        Questions
+                      </a>
+                    </div>
+                  </td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% else %}
+          <div class="empty-state">
+            <i class="fas fa-layer-group"></i>
+            <h3>No subtopics found</h3>
+            <p>Use the manage subtopics tool to add new subtopics for {{ subject.name }}.</p>
+          </div>
+          {% endif %}
+        </section>
+        {% endfor %}
+        {% else %}
+        <div class="empty-state">
+          <i class="fas fa-layer-group"></i>
+          <h3>No subjects available</h3>
+          <p>Create a subject to begin organising your curriculum.</p>
+          <a href="/admin/subjects/create" class="btn-primary">
+            <i class="fas fa-plus"></i>
+            Create Subject
+          </a>
+        </div>
+        {% endif %}
+        {% endif %}
+      </main>
+    </div>
+
+    {% include 'admin/partials/overview_styles.html' %}
+  </body>
+</html>

--- a/self-paced-learning/templates/admin/dashboard.html
+++ b/self-paced-learning/templates/admin/dashboard.html
@@ -138,11 +138,32 @@
                 Manage Lessons
               </a>
               <a
+                href="/admin/overview/lessons"
+                class="action-btn secondary"
+              >
+                <i class="fas fa-book-reader"></i>
+                View All Lessons
+              </a>
+              <a
+                href="/admin/overview/subtopics"
+                class="action-btn secondary"
+              >
+                <i class="fas fa-layer-group"></i>
+                View All Subtopics
+              </a>
+              <a
                 href="/admin/questions/select-subject"
                 class="action-btn secondary"
               >
                 <i class="fas fa-plus-circle"></i>
                 Add Questions
+              </a>
+              <a
+                href="/admin/overview/questions"
+                class="action-btn secondary"
+              >
+                <i class="fas fa-list-ol"></i>
+                View All Questions
               </a>
               <a href="/admin/export" class="action-btn tertiary">
                 <i class="fas fa-download"></i>

--- a/self-paced-learning/templates/admin/partials/overview_styles.html
+++ b/self-paced-learning/templates/admin/partials/overview_styles.html
@@ -1,0 +1,472 @@
+<style>
+  .admin-body {
+    background: #f8f9fa;
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    color: #2d3748;
+  }
+
+  .admin-layout {
+    display: flex;
+    min-height: 100vh;
+  }
+
+  .admin-sidebar {
+    width: 280px;
+    background: #1a2332;
+    color: #fff;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  .admin-logo {
+    padding: 20px;
+    border-bottom: 1px solid #2d3748;
+    text-align: center;
+  }
+
+  .admin-logo h2 {
+    margin: 0;
+    font-size: 1.5rem;
+  }
+
+  .back-to-site {
+    color: #a0aec0;
+    text-decoration: none;
+    font-size: 0.9rem;
+    margin-top: 10px;
+    display: inline-block;
+  }
+
+  .back-to-site:hover {
+    color: #63b3ed;
+  }
+
+  .admin-nav {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .admin-nav li {
+    list-style: none;
+  }
+
+  .admin-nav li a,
+  .admin-nav li span.nav-heading {
+    display: block;
+    padding: 14px 22px;
+    color: #a0aec0;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border-left: 3px solid transparent;
+    font-size: 0.95rem;
+  }
+
+  .admin-nav li span.nav-heading {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: #718096;
+    border-left: none;
+    padding-top: 18px;
+    padding-bottom: 6px;
+  }
+
+  .admin-nav li a:hover,
+  .admin-nav li a.active {
+    background: #2d3748;
+    color: #63b3ed;
+    border-left-color: #63b3ed;
+  }
+
+  .admin-nav li a i {
+    margin-right: 10px;
+    width: 18px;
+    text-align: center;
+  }
+
+  .admin-content {
+    flex: 1;
+    padding: 32px;
+    overflow-y: auto;
+  }
+
+  .admin-header {
+    margin-bottom: 30px;
+  }
+
+  .header-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 20px;
+  }
+
+  .admin-header h1 {
+    margin: 0;
+    font-size: 2.2rem;
+    color: #2d3748;
+  }
+
+  .admin-header p {
+    margin: 6px 0 0 0;
+    color: #718096;
+  }
+
+  .admin-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    row-gap: 0.2rem;
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .btn-link,
+  .btn-small {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.25s ease;
+  }
+
+  .btn-primary {
+    background: #4299e1;
+    color: #fff;
+  }
+
+  .btn-primary:hover {
+    background: #3182ce;
+  }
+
+  .btn-secondary {
+    background: #e2e8f0;
+    color: #2d3748;
+  }
+
+  .btn-secondary:hover {
+    background: #cbd5e0;
+  }
+
+  .btn-link {
+    color: #4299e1;
+    padding-left: 0;
+    padding-right: 0;
+    background: transparent;
+  }
+
+  .btn-link:hover {
+    color: #2b6cb0;
+  }
+
+  .btn-small {
+    padding: 8px 14px;
+    font-size: 0.85rem;
+    background: #edf2f7;
+    color: #2d3748;
+  }
+
+  .btn-small:hover {
+    background: #e2e8f0;
+  }
+
+  .stats-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+  }
+
+  .stat-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 24px;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    display: flex;
+    align-items: center;
+    gap: 18px;
+  }
+
+  .stat-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.6rem;
+    color: #fff;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  }
+
+  .stat-info h3 {
+    margin: 0;
+    font-size: 1.9rem;
+    font-weight: 700;
+  }
+
+  .stat-info p {
+    margin: 4px 0 0 0;
+    color: #718096;
+    font-size: 0.9rem;
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+  }
+
+  .summary-card {
+    background: #fff;
+    border-radius: 12px;
+    padding: 22px;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+    border-top: 4px solid #4299e1;
+  }
+
+  .summary-card h3 {
+    margin: 0 0 10px 0;
+    font-size: 1.2rem;
+  }
+
+  .summary-card p {
+    margin: 6px 0 0 0;
+    color: #718096;
+    font-size: 0.9rem;
+  }
+
+  .table-container {
+    background: #fff;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+    margin-bottom: 30px;
+  }
+
+  .admin-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .admin-table thead {
+    background: #f7fafc;
+  }
+
+  .admin-table th,
+  .admin-table td {
+    padding: 14px 18px;
+    text-align: left;
+    border-bottom: 1px solid #e2e8f0;
+    vertical-align: top;
+  }
+
+  .admin-table th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #4a5568;
+  }
+
+  .admin-table tbody tr:hover {
+    background: #f8fafc;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  .badge.success {
+    background: rgba(56, 161, 105, 0.15);
+    color: #2f855a;
+  }
+
+  .badge.warning {
+    background: rgba(237, 137, 54, 0.18);
+    color: #c05621;
+  }
+
+  .badge.danger {
+    background: rgba(245, 101, 101, 0.18);
+    color: #c53030;
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: #edf2f7;
+    color: #2d3748;
+  }
+
+  .status-pill.good {
+    background: rgba(72, 187, 120, 0.2);
+    color: #276749;
+  }
+
+  .status-pill.warn {
+    background: rgba(236, 201, 75, 0.25);
+    color: #975a16;
+  }
+
+  .status-pill.bad {
+    background: rgba(245, 101, 101, 0.2);
+    color: #9b2c2c;
+  }
+
+  .subject-section {
+    margin-bottom: 40px;
+  }
+
+  .subject-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 18px;
+  }
+
+  .subject-title {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .subtopic-section {
+    background: #fff;
+    border-radius: 12px;
+    padding: 20px;
+    margin-bottom: 16px;
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+  }
+
+  .subtopic-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 18px;
+    align-items: flex-start;
+    margin-bottom: 16px;
+  }
+
+  .subtopic-header h3 {
+    margin: 0;
+    font-size: 1.3rem;
+    color: #2d3748;
+  }
+
+  .subtopic-header p {
+    margin: 8px 0 0 0;
+    color: #718096;
+  }
+
+  .subtopic-meta {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    row-gap: 0.2rem;
+  }
+
+  .nested-table {
+    margin-top: 16px;
+  }
+
+  .nested-table .admin-table {
+    margin-bottom: 0;
+  }
+
+  .empty-state.compact {
+    padding: 32px 20px;
+  }
+
+  .subject-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    color: #fff;
+  }
+
+  .empty-state {
+    background: #fff;
+    border-radius: 12px;
+    padding: 60px 20px;
+    text-align: center;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+    color: #718096;
+  }
+
+  .empty-state i {
+    font-size: 3rem;
+    margin-bottom: 16px;
+    color: #cbd5e0;
+  }
+
+  .empty-state h3 {
+    margin: 0 0 10px 0;
+    color: #2d3748;
+  }
+
+  @media (max-width: 1024px) {
+    .admin-layout {
+      flex-direction: column;
+    }
+
+    .admin-sidebar {
+      width: 100%;
+    }
+
+    .header-actions {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .admin-actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
+
+    .subject-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .admin-content {
+      padding: 24px 20px;
+    }
+
+    .stats-overview {
+      grid-template-columns: 1fr;
+    }
+
+    .summary-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .admin-table th,
+    .admin-table td {
+      padding: 12px 14px;
+    }
+  }
+</style>

--- a/self-paced-learning/tests/test_routes_comprehensive.py
+++ b/self-paced-learning/tests/test_routes_comprehensive.py
@@ -100,6 +100,9 @@ class TestAllRoutes(unittest.TestCase):
             ("/admin/subtopics/select-subject", "Select subject for subtopics"),
             ("/admin/lessons/select-subject", "Select subject for lessons"),
             ("/admin/questions/select-subject", "Select subject for questions"),
+            ("/admin/overview/lessons", "All lessons overview"),
+            ("/admin/overview/subtopics", "All subtopics overview"),
+            ("/admin/overview/questions", "All questions overview"),
         ]
 
         for route, description in admin_routes:
@@ -121,6 +124,27 @@ class TestAllRoutes(unittest.TestCase):
                     )
                 else:
                     print(f"    ❌ {response.status_code} - Error in {description}")
+
+    def test_admin_overview_pages_content(self):
+        """Ensure overview pages render aggregated data."""
+
+        overview_pages = [
+            ("/admin/overview/lessons", "All Lessons Overview", "Python Functions"),
+            ("/admin/overview/questions", "All Questions Overview", "Python Functions"),
+            ("/admin/overview/subtopics", "All Subtopics Overview", "Python Functions"),
+        ]
+
+        for route, headline, expected in overview_pages:
+            with self.subTest(route=route):
+                response = self.client.get(route)
+                self.assertEqual(
+                    response.status_code,
+                    200,
+                    f"Overview page {route} should return 200",
+                )
+                content = response.get_data(as_text=True)
+                self.assertIn(headline, content)
+                self.assertIn(expected, content)
 
     def test_api_routes(self):
         """Test API endpoints."""


### PR DESCRIPTION
## Summary
- add a slight row gap to the admin actions and subtopic metadata flex containers so wrapped controls breathe better

## Testing
- pytest *(fails: existing suites expect `DataService()` without a data root, `test_video_data_management` uses a dict for videos so indexing fails, and `/dev/test-services` responds with 403)*
- python -m pip install flake8 *(fails: proxy prevents downloading the package)*

------
https://chatgpt.com/codex/tasks/task_e_68e07cd01e30832f8324379773a0eb6a