### PR TITLE
Fix remedial quiz follow-up flow

### DIFF
--- a/self-paced-learning/blueprints/main_routes.py
+++ b/self-paced-learning/blueprints/main_routes.py
@@ -545,6 +545,14 @@ def generate_remedial_quiz():
                 "error": "We couldn't find follow-up questions for your weak topics. Please review the materials and try again.",
             }), 404
 
+        # Limit stored remedial questions to avoid overflowing the client-side
+        # session cookie. Very large payloads can cause Flask's secure cookie to
+        # exceed browser limits, which then prevents the follow-up quiz from
+        # loading properly.
+        MAX_REMEDIAL_QUESTIONS = 10
+        if len(remedial_questions) > MAX_REMEDIAL_QUESTIONS:
+            remedial_questions = remedial_questions[:MAX_REMEDIAL_QUESTIONS]
+
         progress_service.set_remedial_quiz_data(
             current_subject, current_subtopic, remedial_questions, weak_topics
         )

--- a/self-paced-learning/static/css/styles.css
+++ b/self-paced-learning/static/css/styles.css
@@ -286,6 +286,14 @@ h2 {
   box-shadow: 0 4px 15px rgba(225, 112, 85, 0.3);
 }
 
+.status-info {
+  background: linear-gradient(135deg, #a29bfe 0%, #6c5ce7 100%);
+  border: none;
+  color: white;
+  border-radius: 10px;
+  box-shadow: 0 4px 15px rgba(162, 155, 254, 0.3);
+}
+
 .feedback-section {
   margin-top: 25px;
   padding: 20px;

--- a/self-paced-learning/templates/results.html
+++ b/self-paced-learning/templates/results.html
@@ -385,9 +385,52 @@
 
               // --- Score Display Function (duplicate click handler removed) ---
 
-              continueButton.addEventListener("click", function () {
-                if (!this.disabled) {
-                  window.location.href = "/generate_remedial_quiz";
+              continueButton.addEventListener("click", async function () {
+                if (this.disabled) {
+                  return;
+                }
+
+                const button = this;
+                button.disabled = true;
+
+                if (statusDiv) {
+                  statusDiv.textContent = "Preparing your follow-up quiz...";
+                  statusDiv.className = "status status-info";
+                  statusDiv.classList.remove("hidden");
+                }
+
+                try {
+                  const response = await fetch("/generate_remedial_quiz", {
+                    headers: {
+                      Accept: "application/json",
+                    },
+                  });
+
+                  if (!response.ok) {
+                    throw new Error(
+                      "We couldn't prepare the follow-up quiz. Please try again."
+                    );
+                  }
+
+                  const data = await response.json();
+
+                  if (data && data.success && data.redirect_url) {
+                    window.location.href = data.redirect_url;
+                    return;
+                  }
+
+                  const message =
+                    (data && (data.error || data.message)) ||
+                    "We couldn't prepare the follow-up quiz. Please try again.";
+                  throw new Error(message);
+                } catch (error) {
+                  console.error("Failed to generate remedial quiz", error);
+                  if (statusDiv) {
+                    statusDiv.textContent = error.message;
+                    statusDiv.className = "status status-error";
+                    statusDiv.classList.remove("hidden");
+                  }
+                  button.disabled = false;
                 }
               });
 


### PR DESCRIPTION
## Summary
- fetch remedial quiz generation from the results page so the button redirects to the follow-up quiz instead of the JSON response
- show a neutral status style while preparing the follow-up quiz
- cap the number of remedial questions stored per attempt to avoid overflowing the session cookie

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e4777684832f8375aadbcb08088b