### PR TITLE
Add subject-level cache clearing support

### DIFF
--- a/self-paced-learning/services/data_service.py
+++ b/self-paced-learning/services/data_service.py
@@ -416,3 +416,7 @@ class DataService:
     def clear_cache_for_subject_subtopic(self, subject: str, subtopic: str) -> None:
         """Clear cache for specific subject/subtopic."""
         self.data_loader.clear_cache_for_subject_subtopic(subject, subtopic)
+
+    def clear_cache_for_subject(self, subject: str) -> None:
+        """Clear all cached data for a subject."""
+        self.data_loader.clear_cache_for_subject(subject)

--- a/self-paced-learning/utils/data_loader.py
+++ b/self-paced-learning/utils/data_loader.py
@@ -310,6 +310,17 @@ class DataLoader:
         for key in cache_keys_to_remove:
             del self._cache[key]
 
+    def clear_cache_for_subject(self, subject: str) -> None:
+        """Clear all cache entries related to a subject."""
+        cache_keys_to_remove = [
+            key
+            for key in list(self._cache.keys())
+            if key == subject or key.startswith(f"{subject}_")
+        ]
+
+        for key in cache_keys_to_remove:
+            del self._cache[key]
+
     def validate_subject_subtopic(self, subject: str, subtopic: str) -> bool:
         """
         Check if a subject/subtopic combination exists.


### PR DESCRIPTION
## Summary
- add a subject-wide cache clearing helper to the data loader
- expose the new helper through the data service for use by admin routes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3ef1d7bac832fb6fd13c66e9da568