### PR TITLE
Fix DataLoader relative path resolution

### DIFF
--- a/self-paced-learning/utils/data_loader.py
+++ b/self-paced-learning/utils/data_loader.py
@@ -19,7 +19,20 @@ class DataLoader:
         Args:
             data_root_path: Path to the data directory (e.g., "/path/to/data")
         """
-        self.data_root = data_root_path
+        # Resolve the data root path so relative inputs such as "data" continue
+        # to work regardless of the current working directory of the running
+        # process.  When the initial absolute resolution does not exist we fall
+        # back to resolving relative to the project root (one directory above
+        # this utils module).
+        resolved_root = os.path.abspath(data_root_path)
+
+        if not os.path.exists(resolved_root) and not os.path.isabs(data_root_path):
+            module_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+            candidate = os.path.join(module_root, data_root_path)
+            if os.path.exists(candidate):
+                resolved_root = candidate
+
+        self.data_root = resolved_root
         self._cache = {}
 
     def _load_json_file(self, file_path: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- resolve the DataLoader's data root when a relative path is provided so admin tools locate bundled content

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e412f5070c832fafda17bb03d1b51c