### PR TITLE
Fix remedial quiz launch and shrink session payloads

### DIFF
--- a/self-paced-learning/blueprints/main_routes.py
+++ b/self-paced-learning/blueprints/main_routes.py
@@ -545,14 +545,15 @@ def generate_remedial_quiz():
                 "error": "We couldn't find follow-up questions for your weak topics. Please review the materials and try again.",
             }), 404
 
-        progress_service.set_remedial_quiz_data(
+        stored_count = progress_service.set_remedial_quiz_data(
             current_subject, current_subtopic, remedial_questions, weak_topics
         )
 
         return jsonify(
             {
                 "success": True,
-                "question_count": len(remedial_questions),
+                "question_count": stored_count,
+                "stored_question_count": stored_count,
                 "redirect_url": url_for("main.take_remedial_quiz_page"),
             }
         )

--- a/self-paced-learning/templates/results.html
+++ b/self-paced-learning/templates/results.html
@@ -385,10 +385,46 @@
 
               // --- Score Display Function (duplicate click handler removed) ---
 
-              continueButton.addEventListener("click", function () {
-                if (!this.disabled) {
-                  window.location.href = "/generate_remedial_quiz";
+              continueButton.addEventListener("click", async function (event) {
+                event.preventDefault();
+                if (this.disabled) {
+                  return;
                 }
+
+                const originalText = this.textContent;
+                this.disabled = true;
+                this.textContent = "Loading...";
+
+                try {
+                  const response = await fetch("/generate_remedial_quiz", {
+                    headers: {
+                      Accept: "application/json",
+                    },
+                    credentials: "same-origin",
+                  });
+
+                  if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`);
+                  }
+
+                  const data = await response.json();
+
+                  if (data.success && data.redirect_url) {
+                    window.location.href = data.redirect_url;
+                    return;
+                  }
+
+                  const errorMessage =
+                    (data && (data.error || data.message)) ||
+                    "Unable to start the follow-up quiz. Please review the lessons and try again.";
+                  alert(errorMessage);
+                } catch (error) {
+                  console.error("Error starting remedial quiz:", error);
+                  alert("We couldn't start the follow-up quiz. Please try again.");
+                }
+
+                this.disabled = false;
+                this.textContent = originalText;
               });
 
               // Admin mark complete functionality


### PR DESCRIPTION
## Summary
- convert the remedial follow-up button into an async fetch that redirects with JSON feedback
- sanitize stored quiz questions and cap remedial counts to keep Flask session cookies under the limit
- surface stored question counts in the remedial quiz response for easier debugging

## Testing
- `ruff check services/progress_service.py`
- `ruff check blueprints/main_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e420a24c5c832fa5f94d1480fc8df2