### PR TITLE
Expand remedial quiz coverage and refresh session context

### DIFF
--- a/self-paced-learning/services/progress_service.py
+++ b/self-paced-learning/services/progress_service.py
@@ -311,7 +311,7 @@ class ProgressService:
     ) -> None:
         """Persist remedial quiz questions and related topics."""
         sanitized_questions = self._sanitize_questions_for_session(
-            questions, max_questions=3
+            questions, max_questions=10
         )
         questions_key = self.get_session_key(subject, subtopic, "remedial_questions")
         session[questions_key] = sanitized_questions


### PR DESCRIPTION
## Summary
- update remedial quiz selection to surface 7-10 questions that prioritize the learner's weak topics
- persist the larger remedial question set in session and reset the quiz context when launching the follow-up quiz
- expand automated coverage to verify remedial question selection and that the remedial quiz analysis uses the refreshed context

## Testing
- pytest
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e5d0262f6c832f90d4585f2295b411